### PR TITLE
Add group for service project

### DIFF
--- a/ansible/script/keystone.sh
+++ b/ansible/script/keystone.sh
@@ -87,6 +87,9 @@ create_user_and_endpoint(){
     . $DEV_STACK_DIR/openrc admin admin
     openstack user create --domain default --password $STACK_PASSWORD $OPENSDS_SERVER_NAME
     openstack role add --project service --user opensds admin
+    openstack group create service
+    openstack group add user service opensds
+    openstack role add service --project service --group service
     openstack service create --name opensds$OPENSDS_VERSION --description "OpenSDS Block Storage" opensds$OPENSDS_VERSION
     openstack endpoint create --region RegionOne opensds$OPENSDS_VERSION public http://$HOST_IP:50040/$OPENSDS_VERSION/%\(tenant_id\)s
     openstack endpoint create --region RegionOne opensds$OPENSDS_VERSION internal http://$HOST_IP:50040/$OPENSDS_VERSION/%\(tenant_id\)s


### PR DESCRIPTION
As we known keystone has an auth design on domain, project, role, user. To facilitate the use of keystone, we should unify and simplify the relationship of domain, project, role and user:

- domain uses `default` domain.
- each project has a group with anonymous name.
- each group is assigned with a role.
- users are added into group.