### PR TITLE
Fix bugs when installing nodejs

### DIFF
--- a/ansible/roles/dashboard-installer/scenarios/use-source-code.yml
+++ b/ansible/roles/dashboard-installer/scenarios/use-source-code.yml
@@ -21,6 +21,7 @@
   shell:  "{{ item }}"
   with_items:
       - curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash - 
+      - apt-get update
       - apt install -y nodejs
   become: yes
   


### PR DESCRIPTION
To install nodejs normmally, the command `apt-get update` should be executed after adding nodejs source into ubuntu source list.