### PR TITLE
Fix 80 port conflict when installing nginx

### DIFF
--- a/ansible/roles/dashboard-installer/scenarios/source-code.yml
+++ b/ansible/roles/dashboard-installer/scenarios/source-code.yml
@@ -49,9 +49,14 @@
   register: dashboardexisted
     
 - name: build and configure opensds dashboard
-  shell: make
+  shell: "{{ item }}"
+  with_items:
+    - service apache2 stop
+    - make
+    - service apache2 start
   args:
     chdir: "{{ go_path }}/src/github.com/opensds/opensds/dashboard"
+    warn: false
   become: yes
 
 - name: restart nginx


### PR DESCRIPTION
Both Nginx and Apache2 use 80 as default server port. If Apache2 is installed previously, then installing nginx will fail. So we can stop apache2 service when installing nginx and restart apach2 after installing and reconfiguring nginx(such as change 80 to 8088).