### PR TITLE
Fix cinder standalone install error

### DIFF
--- a/ansible/group_vars/osdsdock.yml
+++ b/ansible/group_vars/osdsdock.yml
@@ -83,7 +83,7 @@ cinder_image_tag: debian-cinder
 # removed when use ansible script clean environment.
 cinder_volume_group: cinder-volumes
 # All source code and volume group file will be placed in the cinder_data_dir:
-cinder_data_dir: "{{ workplace }}/cinder_data_dir"
+cinder_data_dir: "/opt/cinder_data_dir"
 
 # These fields are not suggested to be modified
 cinder_name: cinder backend

--- a/ansible/roles/osdsdock/scenarios/cinder_standalone.yml
+++ b/ansible/roles/osdsdock/scenarios/cinder_standalone.yml
@@ -133,6 +133,8 @@
     sed -i "s/image: debian-cinder/image: {{ cinder_image_tag }}/g" docker-compose.yml
     sed -i "s/image: lvm-debian-cinder/image: lvm-{{ cinder_image_tag }}/g" docker-compose.yml
 
+    sed -i "s/3306:3306/3307:3306/g" docker-compose.yml
+
     sed -i "s/volume_group = cinder-volumes /volume_group = {{ cinder_volume_group }}/g" etc/cinder.conf
   become: true
   args:


### PR DESCRIPTION
1. Fix the workplace doesn't exist issue.
2. Fix the 3306 port conflicts.