### PR TITLE
Set default availability zone for cinder pool

### DIFF
--- a/ansible/group_vars/cinder/cinder.yaml
+++ b/ansible/group_vars/cinder/cinder.yaml
@@ -25,7 +25,7 @@ authOptions:
 pool:
   "cinder-lvm@lvm#lvm":
     storageType: block
-    availabilityZone: nova
+    availabilityZone: default
     extras:
       dataStorage:
         provisioningPolicy: Thin


### PR DESCRIPTION
Currently opensds use `default` as the default availability zone, so changing nova to default.