### PR TITLE
Set the waiting time of booting cinder service

### DIFF
--- a/ansible/roles/osdsdock/scenarios/cinder_standalone.yml
+++ b/ansible/roles/osdsdock/scenarios/cinder_standalone.yml
@@ -156,5 +156,5 @@
   wait_for:
     host: 127.0.0.1
     port: 8776
-    delay: 2
+    delay: 15
     timeout: 120


### PR DESCRIPTION
The dock daemon in opensds reads the cinder configuration and call the `pools api` of cinder to initialize cinder dock, it will take some time to wait for all daemon(such as cinder-api, cinder-scheduler, cinder-volume and so forth) of cinder to start normally.  So we extend the waiting time to ensure that the cinder service is available.