### PR TITLE
Add dist make target for build packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 .glide/
 
 /bin
+build/
 *.log
 .DS_Store
 *.retry

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,46 @@
+# Copyright (c) 2018 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+BASE_DIR := $(shell pwd)
+DIST_DIR := $(BASE_DIR)/build/dist
+VERSION ?= $(shell git describe --exact-match 2> /dev/null || \
+                 git describe --match=$(git rev-parse --short=8 HEAD) \
+		 --always --dirty --abbrev=8)
+BUILD_TGT := opensds-installer-$(VERSION)
+
+all: help
+
+help:
+	@echo This is used for packaging automation. This repo\'s contents
+	@echo may be used without the need for compilation.
+	@echo
+	@echo Refer to the README file in each subdirectory for specific
+	@echo details for that installer type.
+
+version:
+	@echo ${VERSION}
+
+.PHONY: dist
+dist:
+	( \
+	    rm -fr $(DIST_DIR) && mkdir -p $(DIST_DIR)/$(BUILD_TGT) && \
+	    cd $(DIST_DIR) && \
+	    cp -r $(BASE_DIR)/ansible $(BUILD_TGT)/ && \
+	    cp -r $(BASE_DIR)/charts $(BUILD_TGT)/ && \
+	    cp -r $(BASE_DIR)/conf $(BUILD_TGT)/ && \
+	    cp $(BASE_DIR)/LICENSE $(BUILD_TGT)/ && \
+	    zip -r $(DIST_DIR)/$(BUILD_TGT).zip $(BUILD_TGT) && \
+	    tar zcvf $(DIST_DIR)/$(BUILD_TGT).tar.gz $(BUILD_TGT) && \
+	    tree \
+	)


### PR DESCRIPTION
This is part of an effort to standardize how builds are done
across OpenSDS projects. Adding a common "dist" make target
so build artifacts can more easily be collected across the
different deliverables.

Signed-off-by: Sean McGinnis <sean.mcginnis@gmail.com>