### PR TITLE
Install Ceph packages are part of common system packages

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -31,14 +31,32 @@
   apt:
     update_cache: yes
 
-- name: install make, gcc and pip external packages
-  apt:
+- name: install system packages
+  package:
     name: "{{ item }}"
     state: present
   with_items:
     - make
     - gcc
     - python-pip
+
+- name: install Red Hat system packages
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - librados-devel
+    - librbd-devel
+  when: ansible_os_family == "RedHat"
+
+- name: install Ubuntu system packages
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - librados-dev
+    - librbd-dev
+  when: ansible_os_family == "Debian"
 
 - name: create opensds work directory if it doesn't exist
   file:


### PR DESCRIPTION
The librados and librbd system packages had been installed as part of
the "make all" for the opensds controller rather than being done as
part of the install setup. This fixes that by installing these packages
in a more distro independent way using ansible.

Issue #49