### PR TITLE
Cherry-pick v0.2.1 ansible change to stable/aruba

### DIFF
--- a/ansible/group_vars/common.yml
+++ b/ansible/group_vars/common.yml
@@ -57,14 +57,14 @@ nbp_remote_url: https://github.com/opensds/nbp.git
 ###########
 
 # If user specifies intalling from release,then he can choose the specific version
-opensds_release: v0.2.0 # The version should be at least v0.2.0
-nbp_release: v0.2.0 # The version should be at least v0.2.0
+opensds_release: v0.2.1 # The version should be at least v0.2.1
+nbp_release: v0.2.1 # The version should be at least v0.2.1
 
 # These fields are NOT suggested to be modified
-opensds_download_url: https://github.com/opensds/opensds/releases/download/{{ opensds_release }}/opensds-{{ opensds_release }}-linux-amd64.tar.gz
-opensds_tarball_dir: /tmp/opensds-{{ opensds_release }}-linux-amd64
-nbp_download_url: https://github.com/opensds/nbp/releases/download/{{ nbp_release }}/opensds-k8s-{{ nbp_release }}-linux-amd64.tar.gz
-nbp_tarball_dir: /tmp/opensds-k8s-{{ nbp_release }}-linux-amd64
+opensds_download_url: https://github.com/opensds/opensds/releases/download/{{ opensds_release }}/opensds-hotpot-{{ opensds_release }}-linux-amd64.tar.gz
+opensds_tarball_dir: /tmp/opensds-hotpot-{{ opensds_release }}-linux-amd64
+nbp_download_url: https://github.com/opensds/nbp/releases/download/{{ nbp_release }}/opensds-sushi-{{ nbp_release }}-linux-amd64.tar.gz
+nbp_tarball_dir: /tmp/opensds-sushi-{{ nbp_release }}-linux-amd64
 
 
 #############


### PR DESCRIPTION
Cherry-pick v0.2.1 change from master to stable/aruba to prepare for the stable/aruba release