### PR TITLE
Change the default release version to v0.3.0

### DIFF
--- a/ansible/group_vars/common.yml
+++ b/ansible/group_vars/common.yml
@@ -57,8 +57,8 @@ nbp_remote_url: https://github.com/opensds/nbp.git
 ###########
 
 # If user specifies intalling from release,then he can choose the specific version
-opensds_release: v0.2.1 # The version should be at least v0.2.1
-nbp_release: v0.2.1 # The version should be at least v0.2.1
+opensds_release: v0.3.0 # The version should be at least v0.2.1
+nbp_release: v0.3.0 # The version should be at least v0.2.1
 
 # These fields are NOT suggested to be modified
 opensds_download_url: https://github.com/opensds/opensds/releases/download/{{ opensds_release }}/opensds-hotpot-{{ opensds_release }}-linux-amd64.tar.gz


### PR DESCRIPTION
Signed-off-by: leonwanghui <wanghui71leon@gmail.com>

This patch is proposed for changing default release version to v0.3.0, so as to comply with OpenSDS Bali milestone-1.