### PR TITLE
Enabled OpenSDS Ansible installation with pre-existing Ceph

### DIFF
--- a/ansible/group_vars/osdsdock.yml
+++ b/ansible/group_vars/osdsdock.yml
@@ -23,7 +23,7 @@ dummy:
 ###########
 
 # Change it according to your backend, currently support 'lvm', 'ceph', 'cinder'
-enabled_backend: ceph
+enabled_backend: lvm
 # Change it according to your node type (host or target), currently support
 # 'provisioner', 'attacher'
 dock_type: provisioner

--- a/ansible/group_vars/osdsdock.yml
+++ b/ansible/group_vars/osdsdock.yml
@@ -23,10 +23,16 @@ dummy:
 ###########
 
 # Change it according to your backend, currently support 'lvm', 'ceph', 'cinder'
-enabled_backend: lvm
+enabled_backend: ceph
 # Change it according to your node type (host or target), currently support
 # 'provisioner', 'attacher'
 dock_type: provisioner
+
+#If you are using clean and not defined hard disk for osd enable and mention devices ( Do not use it if you are using loop device or losetup command to configure disk for osd
+
+#devices:
+# - '/dev/sdb'
+#osd_objectstore: bluestore
 
 
 ###########

--- a/ansible/roles/osdsdock/scenarios/ceph.yml
+++ b/ansible/roles/osdsdock/scenarios/ceph.yml
@@ -30,7 +30,7 @@
   with_items:
     - ceph-common
   when: res["results"][0]["rc"] == 1
- 
+
 - name: install notario package with pip when ceph backend enabled
   pip:
     name: "{{ item }}"
@@ -108,30 +108,30 @@
     - ansible all -m ping -i ceph.hosts
     - ansible-playbook site.yml -i ceph.hosts | tee /var/log/ceph_ansible.log
   args:
-    chdir: /opt/ceph-ansible 
+    chdir: /opt/ceph-ansible
   when: res["results"][0]["rc"] == 1 or service_ceph_mon_status.rc == 1 or service_ceph_osd_status.rc == 1
 
-- name: Configure Ceph-OSD
-  shell: "{{ item }}" 
-  become: true
-  ignore_errors: true
-  with_items:
-    - ceph-disk prepare --bluestore /dev/sdb #Change this device to your device for eg. /dev/sdv, /dev/sdc etc
-    - sleep 5
-  when: res["results"][0]["rc"] == 1
+#- name: Prepare disk for Ceph-OSD # Use this if you are using Clean and Empty hard disk and NOT LOOP DEVICES
+#  shell: "{{ item }}"
+#  become: true
+#  ignore_errors: true
+#  with_items:
+#    - ceph-disk prepare --bluestore "{{ devices }}"
+#    - sleep 5
+#  when: res["results"][0]["rc"] == 1
 
 - name: check if ceph osd is running
   shell: ps aux | grep ceph-osd | grep -v grep
   ignore_errors: true
   changed_when: false
   register: service_ceph_osd_status
-  
+
 - name: check if ceph mon is running
   shell: ps aux | grep ceph-mon | grep -v grep
   ignore_errors: true
   changed_when: false
   register: service_ceph_mon_status
-  
+
 - name: configure profile and disable some features in ceph for kernel compatible.
   shell: "{{ item }}"
   become: true

--- a/ansible/roles/osdsdock/scenarios/ceph.yml
+++ b/ansible/roles/osdsdock/scenarios/ceph.yml
@@ -13,13 +13,24 @@
 # limitations under the License.
 
 ---
+- name: check ceph version
+  shell: "{{ item }}"
+  with_items:
+    - bash ./script/check_ceph_version.sh
+  become: yes
+  ignore_errors: true
+  register: res
+- debug:
+    var: res["results"][0]["rc"]
+
 - name: install ceph-common external package when ceph backend enabled
   apt:
     name: "{{ item }}"
     state: present
   with_items:
     - ceph-common
-
+  when: res["results"][0]["rc"] == 1
+ 
 - name: install notario package with pip when ceph backend enabled
   pip:
     name: "{{ item }}"
@@ -44,6 +55,20 @@
     src: ../../../group_vars/ceph/ceph.yaml
     dest: "{{ ceph_config_path }}"
 
+- name: check if ceph osd is running
+  shell: ps aux | grep ceph-osd | grep -v grep
+  ignore_errors: true
+  changed_when: false
+  register: service_ceph_osd_status
+  when: res["results"][0]["rc"] == 0
+
+- name: check if ceph mon is running
+  shell: ps aux | grep ceph-mon | grep -v grep
+  ignore_errors: true
+  changed_when: false
+  register: service_ceph_mon_status
+  when: res["results"][0]["rc"] == 0
+
 - name: check for ceph-ansible source code existed
   stat:
     path: /opt/ceph-ansible
@@ -62,16 +87,19 @@
   copy:
     src: ../../../group_vars/ceph/ceph.hosts
     dest: /opt/ceph-ansible/ceph.hosts
+  when: res["results"][0]["rc"] == 1
 
 - name: copy ceph all.yml file into ceph-ansible group_vars directory
   copy:
     src: ../../../group_vars/ceph/all.yml
     dest: /opt/ceph-ansible/group_vars/all.yml
+  when: res["results"][0]["rc"] == 1
 
 - name: copy site.yml.sample to site.yml in ceph-ansible
   copy:
     src: /opt/ceph-ansible/site.yml.sample
     dest: /opt/ceph-ansible/site.yml
+  when: res["results"][0]["rc"] == 1
 
 - name: ping all hosts and run ceph-ansible playbook
   shell: "{{ item }}"
@@ -80,26 +108,37 @@
     - ansible all -m ping -i ceph.hosts
     - ansible-playbook site.yml -i ceph.hosts | tee /var/log/ceph_ansible.log
   args:
-    chdir: /opt/ceph-ansible
+    chdir: /opt/ceph-ansible 
+  when: res["results"][0]["rc"] == 1 or service_ceph_mon_status.rc == 1 or service_ceph_osd_status.rc == 1
+
+- name: Configure Ceph-OSD
+  shell: "{{ item }}" 
+  become: true
+  ignore_errors: true
+  with_items:
+    - ceph-disk prepare --bluestore /dev/sdb #Change this device to your device for eg. /dev/sdv, /dev/sdc etc
+    - sleep 5
+  when: res["results"][0]["rc"] == 1
 
 - name: check if ceph osd is running
   shell: ps aux | grep ceph-osd | grep -v grep
   ignore_errors: true
   changed_when: false
   register: service_ceph_osd_status
-
+  
 - name: check if ceph mon is running
   shell: ps aux | grep ceph-mon | grep -v grep
   ignore_errors: true
   changed_when: false
   register: service_ceph_mon_status
-
+  
 - name: configure profile and disable some features in ceph for kernel compatible.
   shell: "{{ item }}"
   become: true
   ignore_errors: yes
   with_items:
     - ceph osd crush tunables hammer
+    - sleep 5 
     - grep -q "^rbd default features" /etc/ceph/ceph.conf || sed -i '/\[global\]/arbd default features = 1' /etc/ceph/ceph.conf
   when: service_ceph_mon_status.rc == 0 and service_ceph_osd_status.rc == 0
 
@@ -109,3 +148,4 @@
   changed_when: false
   with_items: "{{ ceph_pools }}"
   when: service_ceph_mon_status.rc == 0 and service_ceph_osd_status.rc == 0
+

--- a/ansible/script/check_ceph_version.sh
+++ b/ansible/script/check_ceph_version.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2018 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cephver=$(ceph --version |grep -Eow '^ceph version [^ ]+' |gawk '{ print $3 }')
+echo "The actual version of Ceph is $cephver"
+
+if [[ "$cephver" <  10.0.0 ]]; then
+  echo "Ceph installation is required"
+  exit 1
+fi
+
+exit 0
+

--- a/ansible/script/check_ceph_version.sh
+++ b/ansible/script/check_ceph_version.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright (c) 2018 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright (c) 2019 Click2Cloud Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 cephver=$(ceph --version |grep -Eow '^ceph version [^ ]+' |gawk '{ print $3 }')
 echo "The actual version of Ceph is $cephver"
 
-if [[ "$cephver" <  10.0.0 ]]; then
+if [[ "$cephver" <  1.0.0 ]]; then
   echo "Ceph installation is required"
   exit 1
 fi


### PR DESCRIPTION
This PR adds capability to skip Ceph installation process if it already exist during OpenSDS cluster installation process using Ansible.