### PR TITLE
Enabled multiple backend in OpenSDS-ansible installer

### DIFF
--- a/ansible/group_vars/osdsdock.yml
+++ b/ansible/group_vars/osdsdock.yml
@@ -23,7 +23,7 @@ dummy:
 ###########
 
 # Change it according to your backend, currently support 'lvm', 'ceph', 'cinder'
-enabled_backend: lvm #For Multi-backend add backends here, for eg. enabled_backends: lvm,ceph,cinder
+enabled_backends: lvm #For Multi-backend add backends here, for eg. enabled_backends: lvm,ceph,cinder
 # Change it according to your node type (host or target), currently support
 # 'provisioner', 'attacher'
 dock_type: provisioner

--- a/ansible/group_vars/osdsdock.yml
+++ b/ansible/group_vars/osdsdock.yml
@@ -23,10 +23,7 @@ dummy:
 ###########
 
 # Change it according to your backend, currently support 'lvm', 'ceph', 'cinder'
-enabled_backend: 
-  - lvm
-  #- ceph
-  #- cinder
+enabled_backend: lvm #For Multi-backend add backends here, for eg. enabled_backends: lvm,ceph,cinder
 # Change it according to your node type (host or target), currently support
 # 'provisioner', 'attacher'
 dock_type: provisioner

--- a/ansible/group_vars/osdsdock.yml
+++ b/ansible/group_vars/osdsdock.yml
@@ -23,7 +23,10 @@ dummy:
 ###########
 
 # Change it according to your backend, currently support 'lvm', 'ceph', 'cinder'
-enabled_backend: lvm
+enabled_backend: 
+  - lvm
+  #- ceph
+  #- cinder
 # Change it according to your node type (host or target), currently support
 # 'provisioner', 'attacher'
 dock_type: provisioner

--- a/ansible/roles/cleaner/scenarios/backend.yml
+++ b/ansible/roles/cleaner/scenarios/backend.yml
@@ -76,7 +76,7 @@
   args:
     executable: /bin/bash
   become: true
-  when: enabled_backend == "lvm"
+  when: "'lvm' in enabled_backends"
   ignore_errors: yes
 
 - name: stop cinder-standalone service
@@ -84,7 +84,7 @@
   become: true
   args:
     chdir: "{{ cinder_data_dir }}/cinder/contrib/block-box"
-  when: enabled_backend == "cinder"
+  when: "'cinder' in enabled_backends"
   ignore_errors: yes
 
 - name: clean the volume group of cinder
@@ -150,5 +150,5 @@
   args:
     executable: /bin/bash
   become: true
-  when: enabled_backend == "cinder"
+  when: "'cinder' in enabled_backends"
   ignore_errors: yes

--- a/ansible/roles/hotpot-installer/tasks/main.yml
+++ b/ansible/roles/hotpot-installer/tasks/main.yml
@@ -97,7 +97,7 @@
     # Choose the type of dock resource, only support 'provisioner' and 'attacher'.
     dock_type = {{ dock_type }}
     # Specify which backends should be enabled, sample,ceph,cinder,lvm and so on.
-    enabled_backends = {{ enabled_backend }}
+    enabled_backends = {{ enabled_backends }}
 
     [database]
     endpoint = {{ db_endpoint }}

--- a/ansible/roles/osdsdock/tasks/main.yml
+++ b/ansible/roles/osdsdock/tasks/main.yml
@@ -15,22 +15,22 @@
 ---
 - name: include scenarios/lvm.yml
   include: scenarios/lvm.yml
-  when: deploy_project != "gelato" and "lvm" in enabled_backend
+  when: deploy_project != "gelato" and "lvm" in enabled_backends
 
 - name: include scenarios/ceph.yml
   include: scenarios/ceph.yml
-  when: deploy_project != "gelato" and "ceph" in enabled_backend
+  when: deploy_project != "gelato" and "ceph" in enabled_backends
 
 - name: include scenarios/cinder.yml
   include: scenarios/cinder.yml
   when:
-   - deploy_project != "gelato" and "cinder" in enabled_backend
+   - deploy_project != "gelato" and "cinder" in enabled_backends
    - use_cinder_standalone == false
 
 - name: include scenarios/cinder_standalone.yml
   include: scenarios/cinder_standalone.yml
   when: 
-   - deploy_project != "gelato" and "cinder" in enabled_backend
+   - deploy_project != "gelato" and "cinder" in enabled_backends
    - use_cinder_standalone == true
  
 - name: run osdsdock daemon service

--- a/ansible/roles/osdsdock/tasks/main.yml
+++ b/ansible/roles/osdsdock/tasks/main.yml
@@ -15,22 +15,22 @@
 ---
 - name: include scenarios/lvm.yml
   include: scenarios/lvm.yml
-  when: deploy_project != "gelato" and "'lvm' in enabled_backends"
+  when: deploy_project != "gelato" and "lvm" in enabled_backends
 
 - name: include scenarios/ceph.yml
   include: scenarios/ceph.yml
-  when: deploy_project != "gelato" and "'ceph' in enabled_backends"
+  when: deploy_project != "gelato" and "ceph" in enabled_backends
 
 - name: include scenarios/cinder.yml
   include: scenarios/cinder.yml
   when:
-   - deploy_project != "gelato" and "'cinder' in enabled_backends"
+   - deploy_project != "gelato" and "cinder" in enabled_backends
    - use_cinder_standalone == false
 
 - name: include scenarios/cinder_standalone.yml
   include: scenarios/cinder_standalone.yml
   when: 
-   - deploy_project != "gelato" and "'cinder' in enabled_backends"
+   - deploy_project != "gelato" and "cinder" in enabled_backends
    - use_cinder_standalone == true
  
 - name: run osdsdock daemon service

--- a/ansible/roles/osdsdock/tasks/main.yml
+++ b/ansible/roles/osdsdock/tasks/main.yml
@@ -15,22 +15,22 @@
 ---
 - name: include scenarios/lvm.yml
   include: scenarios/lvm.yml
-  when: deploy_project != "gelato" and "lvm" in enabled_backends
+  when: deploy_project != "gelato" and "'lvm' in enabled_backends"
 
 - name: include scenarios/ceph.yml
   include: scenarios/ceph.yml
-  when: deploy_project != "gelato" and "ceph" in enabled_backends
+  when: deploy_project != "gelato" and "'ceph' in enabled_backends"
 
 - name: include scenarios/cinder.yml
   include: scenarios/cinder.yml
   when:
-   - deploy_project != "gelato" and "cinder" in enabled_backends
+   - deploy_project != "gelato" and "'cinder' in enabled_backends"
    - use_cinder_standalone == false
 
 - name: include scenarios/cinder_standalone.yml
   include: scenarios/cinder_standalone.yml
   when: 
-   - deploy_project != "gelato" and "cinder" in enabled_backends
+   - deploy_project != "gelato" and "'cinder' in enabled_backends"
    - use_cinder_standalone == true
  
 - name: run osdsdock daemon service

--- a/ansible/roles/osdsdock/tasks/main.yml
+++ b/ansible/roles/osdsdock/tasks/main.yml
@@ -15,24 +15,24 @@
 ---
 - name: include scenarios/lvm.yml
   include: scenarios/lvm.yml
-  when: deploy_project != "gelato" and enabled_backend == "lvm"
+  when: deploy_project != "gelato" and "lvm" in enabled_backend
 
 - name: include scenarios/ceph.yml
   include: scenarios/ceph.yml
-  when: deploy_project != "gelato" and enabled_backend == "ceph"
+  when: deploy_project != "gelato" and "ceph" in enabled_backend
 
 - name: include scenarios/cinder.yml
   include: scenarios/cinder.yml
   when:
-    - deploy_project != "gelato"
-    - enabled_backend == "cinder" and use_cinder_standalone == false
+   - deploy_project != "gelato" and "cinder" in enabled_backend
+   - use_cinder_standalone == false
 
 - name: include scenarios/cinder_standalone.yml
   include: scenarios/cinder_standalone.yml
   when: 
-    - deploy_project != "gelato"
-    - enabled_backend == "cinder" and use_cinder_standalone == true
-
+   - deploy_project != "gelato" and "cinder" in enabled_backend
+   - use_cinder_standalone == true
+ 
 - name: run osdsdock daemon service
   shell:
     cmd: |

--- a/ansible/set_global.sh
+++ b/ansible/set_global.sh
@@ -32,7 +32,7 @@ sed -i 's/^sushi_plugin_type: .*/sushi_plugin_type: '"$sushi_plugin_type"'/g' $v
 sed -i 's/^dashboard_installation_type: .*/dashboard_installation_type: '"$dashboard_installation_type"'/g' $var_path/dashboard.yml
 
 # osdsdock.yml
-sed -i 's/^enabled_backend: .*/enabled_backend: '"$enabled_backend"'/g' $var_path/osdsdock.yml
+sed -i 's/^enabled_backends: .*/enabled_backends: '"$enabled_backends"'/g' $var_path/osdsdock.yml
 
 # etcd
 sed -i 's/^etcd_port: .*/etcd_port: '"$etcd_port"'/g' $var_path/osdsdb.yml


### PR DESCRIPTION
In the process of installing Opensds with multiple backends using Ansible, we have made changes in playbooks so that it will install all backends i.e. Ceph, LVM and Cinder_standalone or as per requirement which is reflecting in "opensds.conf" file 
But it is not reflecting in both UI dashboard and "osdsctl pool list" command ( through osdsctl command it is showing the last installed backend) which is showing only one backend from the backends installed.


