### PR TITLE
Add libffi-dev package for cinder blockbox

### DIFF
--- a/ansible/roles/osdsdock/scenarios/cinder_standalone.yml
+++ b/ansible/roles/osdsdock/scenarios/cinder_standalone.yml
@@ -21,6 +21,7 @@
     - python-pip
     - lvm2
     - thin-provisioning-tools
+    - libffi-dev
     - docker-compose
 
 - name: configure cinder section in opensds global info if specify cinder backend


### PR DESCRIPTION
This package is for Ubuntu/Debian only.