### PR TITLE
clean ceph backend when ceph health status abnormal

### DIFF
--- a/ansible/roles/cleaner/scenarios/backend.yml
+++ b/ansible/roles/cleaner/scenarios/backend.yml
@@ -152,3 +152,8 @@
   become: true
   when: "'cinder' in enabled_backends"
   ignore_errors: yes
+
+- name: clean the ceph backend
+  shell: bash ./script/check_ceph_exist.sh clean
+  when: "'ceph' in enabled_backends"
+  ignore_errors: yes

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -40,3 +40,4 @@
     - gcc
     - python-pip
     - open-iscsi
+    - ceph-deploy

--- a/ansible/script/check_ceph_exist.sh
+++ b/ansible/script/check_ceph_exist.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2019 Click2Cloud Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#check ceph health
+cephver=$(ceph health)
+
+
+#clean ceph backend with ceph_deploy
+clean(){
+  ceph-deploy purge 127.0.0.1
+  ceph-deploy purgedata 127.0.0.1
+  ceph-deploy forgetkeys
+}
+
+exit 0


### PR DESCRIPTION
sometimes,ceph status is HEALTH_WARNING,the osds status is down Even if reinstalled。
I added an operation to clean the CEPH backend in the clean module.
  ceph-deploy purge 127.0.0.1
  ceph-deploy purgedata 127.0.0.1
  ceph-deploy forgetkeys