### PR TITLE
Add osdsapiserver in opensds-installer

### DIFF
--- a/ansible/group_vars/hotpot.yml
+++ b/ansible/group_vars/hotpot.yml
@@ -22,7 +22,8 @@ dummy:
 # GENERAL #
 ###########
 
-controller_endpoint: "{{ host_ip }}:50040"
+controller_endpoint: "{{ host_ip }}:50049"
+apiserver_endpoint: "{{ host_ip }}:50040"
 dock_endpoint: localhost:50050
 
 # These fields are NOT suggested to be modifie
@@ -32,6 +33,7 @@ opensds_config_dir: /etc/opensds
 opensds_driver_config_dir: "{{ opensds_config_dir }}/driver"
 opensds_log_dir: /var/log/opensds
 controller_log_file: "{{ opensds_log_dir }}/osdslet.log"
+apiserver_log_file: "{{ opensds_log_dir }}/osdsapiserver.log"
 dock_log_file: "{{ opensds_log_dir }}/osdsdock.log"
 
 
@@ -51,7 +53,7 @@ hotpot_remote_url: https://github.com/opensds/opensds.git
 ###########
 
 # If user specifies intalling from release,then he can choose the specific version
-hotpot_release: v0.5.0 # The version should be at least v0.2.1
+hotpot_release: v0.6.0 # The version should be at least v0.2.1
 
 # These fields are NOT suggested to be modified
 hotpot_download_url: https://github.com/opensds/opensds/releases/download/{{ hotpot_release }}/opensds-hotpot-{{ hotpot_release }}-linux-amd64.tar.gz

--- a/ansible/roles/cleaner/tasks/main.yml
+++ b/ansible/roles/cleaner/tasks/main.yml
@@ -19,8 +19,8 @@
     state: stopped
   when: dashboard_installation_type == "container"
 
-- name: kill osdslet and osdsdock daemon service
-  shell: killall osdslet osdsdock
+- name: kill osdslet and osdsdock and osdsapiserver daemon service
+  shell: killall osdslet osdsdock osdsapiserver
   when: install_from != "container"
   ignore_errors: true
 

--- a/ansible/roles/hotpot-installer/tasks/main.yml
+++ b/ansible/roles/hotpot-installer/tasks/main.yml
@@ -80,9 +80,11 @@
     cat >> opensds.conf <<OPENSDS_GLOABL_CONFIG_DOC
     [osdslet]
     api_endpoint = {{ controller_endpoint }}
-    graceful = True
     log_file = {{ controller_log_file }}
-    socket_order = inc
+    
+    [osdsapiserver]
+    api_endpoint = {{ apiserver_endpoint }}
+    log_file = {{ apiserver_log_file }}
     auth_strategy = {{ opensds_auth_strategy }}
     # If https is enabled, the default value of cert file
     # is /opt/opensds-security/opensds/opensds-cert.pem, 
@@ -118,6 +120,22 @@
         nohup bin/osdslet > osdslet.out 2> osdslet.err < /dev/null &
         sleep 5
         ps aux | grep osdslet | grep -v grep && break
+      done
+  args:
+    chdir: "{{ hotpot_work_dir }}"
+  when: deploy_project != "gelato" and install_from != "container"
+
+- name: run osdsapiserver daemon service
+  shell:
+    cmd: |
+      i=0
+      while
+        i="$((i+1))"
+        [ "$i" -lt 4 ]
+      do
+        nohup bin/osdsapiserver > osdsapiserver.out 2> osdsapiserver.err < /dev/null &
+        sleep 5
+        ps aux | grep osdsapiserver | grep -v grep && break
       done
   args:
     chdir: "{{ hotpot_work_dir }}"


### PR DESCRIPTION
What this PR does / why we need it:
See [Apiserver decouple request](https://github.com/opensds/opensds/pull/614) for detailed information.

Which issue this PR fixes:
1. Update osdslet and osdsapiserver configuration files for opensds global info
2. Add the operation to start the osdsapiserver service
3. Added the operation of clearing osdsapiserver when install_from is not container
4. update hotpot release to 0.6.0