### PR TITLE
add spiserver  container

### DIFF
--- a/ansible/group_vars/hotpot.yml
+++ b/ansible/group_vars/hotpot.yml
@@ -68,4 +68,5 @@ hotpot_image_tag: latest
 
 # These fields are NOT suggested to be modified
 controller_docker_image: opensdsio/opensds-controller:{{ hotpot_image_tag }}
+apiserver_docker_image: opensdsio/opensds-apiserver:{{ hotpot_image_tag }}
 dock_docker_image: opensdsio/opensds-dock:{{ hotpot_image_tag }}

--- a/ansible/roles/cleaner/tasks/main.yml
+++ b/ansible/roles/cleaner/tasks/main.yml
@@ -31,6 +31,13 @@
     state: stopped
   when: install_from == "container"
 
+- name: kill osdsapiserver containerized service
+  docker_container:
+    name: apiserver
+    image: "{{ apiserver_docker_image }}"
+    state: stopped
+  when: install_from == "container"
+
 - name: kill osdsdock containerized service
   docker_container:
     name: osdsdock

--- a/ansible/roles/hotpot-installer/tasks/main.yml
+++ b/ansible/roles/hotpot-installer/tasks/main.yml
@@ -150,3 +150,13 @@
     volumes:
     - "/etc/opensds/:/etc/opensds"
   when: deploy_project != "gelato" and install_from == "container"
+
+- name: run osdsapiserver containerized service
+  docker_container:
+    name: apiserver
+    image: "{{ apiserver_docker_image }}"
+    state: started
+    network_mode: host
+    volumes:
+    - "/etc/opensds/:/etc/opensds"
+  when: deploy_project != "gelato" and install_from == "container"


### PR DESCRIPTION
What this PR does / why we need it:
See [Add osdsapiserver in opensds-installer](https://github.com/opensds/opensds-installer/pull/130) request for detailed information.

Which issue this PR fixes:
add osdsapiserver daemon start when opensds install from container