### PR TITLE
Update opensds helm charts to latest version

### DIFF
--- a/charts/opensds/templates/deployment.yaml
+++ b/charts/opensds/templates/deployment.yaml
@@ -1,9 +1,26 @@
+# Copyright (c) 2019 The OpenSDS Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+##########################################################################
+# Apiserver deployment
+##########################################################################
 kind: Deployment
 apiVersion: extensions/v1beta1
 metadata:
-  name: {{ template "fullname" . }}-opensds
+  name: {{ template "fullname" . }}-apiserver
   labels:
-    app: {{ template "fullname" . }}-opensds
+    app: {{ template "fullname" . }}-apiserver
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -11,98 +28,284 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "fullname" . }}-opensds
+      app: {{ template "fullname" . }}-apiserver
   template:
     metadata:
       labels:
-        app: {{ template "fullname" . }}-opensds
+        app: {{ template "fullname" . }}-apiserver
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
     spec:
       containers:
-        - name: osdsdb
-          image: {{ .Values.image.osdsdb }}
-          imagePullPolicy: {{ .Values.imagePullPolicy }}
-          volumeMounts:
-            - name: etcd-cert-dir
-              mountPath: /etc/ssl/certs
-        - name: osdsapiserver
-          image: {{ .Values.image.osdsapiserver }}
-          imagePullPolicy: {{ .Values.imagePullPolicy }}
-          command: ["bin/sh"]
-          args: ["-c", "/usr/bin/osdsapiserver -logtostderr"]
-          volumeMounts:
-            - name: opensds-conf-dir
-              mountPath: /etc/opensds
-        - name: osdslet
-          image: {{ .Values.image.osdslet }}
-          imagePullPolicy: {{ .Values.imagePullPolicy }}
-          command: ["bin/sh"]
-          args: ["-c", "/usr/bin/osdslet -logtostderr"]
-          volumeMounts:
-            - name: opensds-conf-dir
-              mountPath: /etc/opensds
-        - name: osdsdock
-          securityContext:
-            privileged: true
-            capabilities:
-              add: ["SYS_ADMIN"]
-            allowPrivilegeEscalation: true
-          image: {{ .Values.image.osdsdock }}
-          imagePullPolicy: {{ .Values.imagePullPolicy }}
-          command: ["bin/sh"]
-          args: ["-c", "/usr/sbin/tgtd; /usr/bin/osdsdock -logtostderr"]
-          volumeMounts:
-            - name: opensds-conf-dir
-              mountPath: /etc/opensds
-            - name: ceph-conf-dir
-              mountPath: /etc/ceph
-            - name: tgt-conf-dir
-              mountPath: /etc/tgt
-              mountPropagation: "Bidirectional"
-            - name: run-dir
-              mountPath: /run
-              mountPropagation: "Bidirectional"
-            - name: dev-dir
-              mountPath: /dev
-              mountPropagation: "HostToContainer"
-            - name: local-time-file
-              mountPath: /etc/localtime
-              readOnly: true
-            - name: lib-modules-dir
-              mountPath: /lib/modules
-              readOnly: true
-      volumes:
-        - name: etcd-cert-dir
-          hostPath:
-            path: /usr/share/ca-certificates/
-            type: Directory
+      - name: osdsapiserver
+        image: {{ .Values.osdsapiserver.image }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        command: ["bin/sh"]
+        args: ["-c", "/usr/bin/osdsapiserver -logtostderr"]
+        ports:
+        - containerPort: 50040
+        volumeMounts:
         - name: opensds-conf-dir
-          hostPath:
-            path: /etc/opensds
-            type: Directory
+          mountPath: /etc/opensds
+      volumes:
+      - name: opensds-conf-dir
+        hostPath:
+          path: /etc/opensds
+          type: Directory
+---
+##########################################################################
+# Controller deployment
+##########################################################################
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: {{ template "fullname" . }}-controller
+  labels:
+    app: {{ template "fullname" . }}-controller
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}-controller
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}-controller
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+        heritage: "{{ .Release.Service }}"
+    spec:
+      containers:
+      - name: osdslet
+        image: {{ .Values.osdslet.image }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        command: ["bin/sh"]
+        args: ["-c", "/usr/bin/osdslet -logtostderr"]
+        ports:
+        - containerPort: 50049
+        volumeMounts:
+        - name: opensds-conf-dir
+          mountPath: /etc/opensds
+      volumes:
+      - name: opensds-conf-dir
+        hostPath:
+          path: /etc/opensds
+          type: Directory
+---
+##########################################################################
+# Dock deployment
+##########################################################################
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: {{ template "fullname" . }}-dock
+  labels:
+    app: {{ template "fullname" . }}-dock
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}-dock
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}-dock
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+        heritage: "{{ .Release.Service }}"
+    spec:
+      containers:
+      - name: osdsdock
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+          allowPrivilegeEscalation: true
+        image: {{ .Values.osdsdock.image }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        command: ["bin/sh"]
+        args: ["-c", "/usr/sbin/tgtd; /usr/bin/osdsdock -logtostderr"]
+        ports:
+        - containerPort: 50050
+        volumeMounts:
+        - name: opensds-conf-dir
+          mountPath: /etc/opensds
         - name: ceph-conf-dir
-          hostPath:
-            path: /etc/ceph
-            type: DirectoryOrCreate
+          mountPath: /etc/ceph
         - name: tgt-conf-dir
-          hostPath:
-            path: /etc/tgt
-            type: Directory
+          mountPath: /etc/tgt
+          mountPropagation: "Bidirectional"
         - name: run-dir
-          hostPath:
-            path: /run
-            type: Directory
+          mountPath: /run
+          mountPropagation: "Bidirectional"
         - name: dev-dir
-          hostPath:
-            path: /dev
-            type: Directory
+          mountPath: /dev
+          mountPropagation: "HostToContainer"
         - name: local-time-file
-          hostPath:
-            path: /etc/localtime
-            type: File
+          mountPath: /etc/localtime
+          readOnly: true
         - name: lib-modules-dir
-          hostPath:
-            path: /lib/modules
-            type: Directory
+          mountPath: /lib/modules
+          readOnly: true
+      volumes:
+      - name: opensds-conf-dir
+        hostPath:
+          path: /etc/opensds
+          type: Directory
+      - name: ceph-conf-dir
+        hostPath:
+          path: /etc/ceph
+          type: DirectoryOrCreate
+      - name: tgt-conf-dir
+        hostPath:
+          path: /etc/tgt
+          type: Directory
+      - name: run-dir
+        hostPath:
+          path: /run
+          type: Directory
+      - name: dev-dir
+        hostPath:
+          path: /dev
+          type: Directory
+      - name: local-time-file
+        hostPath:
+          path: /etc/localtime
+          type: File
+      - name: lib-modules-dir
+        hostPath:
+          path: /lib/modules
+          type: Directory
+---
+##########################################################################
+# Dashboard deployment
+##########################################################################
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: {{ template "fullname" . }}-dashboard
+  labels:
+    app: {{ template "fullname" . }}-dashboard
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}-dashboard
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}-dashboard
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+        heritage: "{{ .Release.Service }}"
+    spec:
+      containers:
+      - name: osdsdashboard
+        image: {{ .Values.osdsdashboard.image }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        env:
+        - name: OPENSDS_AUTH_URL
+          value: http://{{ template "fullname" . }}-authchecker.opensds.svc.cluster.local/identity
+        - name: OPENSDS_HOTPOT_URL
+          value: http://{{ template "fullname" . }}-apiserver.opensds.svc.cluster.local:50040
+        - name: OPENSDS_GELATO_URL
+          value: http://127.0.0.1:8089
+        ports:
+        - containerPort: 8088
+---
+##########################################################################
+# DB deployment
+##########################################################################
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: {{ template "fullname" . }}-db
+  labels:
+    app: {{ template "fullname" . }}-db
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}-db
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}-db
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+        heritage: "{{ .Release.Service }}"
+    spec:
+      containers:
+      - name: osdsdb
+        image: {{ .Values.osdsdb.image }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        command: ["/bin/sh"]
+        args: ["-c", "/usr/local/bin/etcd \
+          --name s1 \
+          --listen-client-urls http://0.0.0.0:2379 \
+          --advertise-client-urls http://0.0.0.0:2379 \
+          --listen-peer-urls http://0.0.0.0:2380 \
+          --initial-advertise-peer-urls http://0.0.0.0:2380 \
+          --initial-cluster s1=http://0.0.0.0:2380"]
+        ports:
+        - containerPort: 2379
+        - containerPort: 2380
+        volumeMounts:
+        - name: etcd-cert-dir
+          mountPath: /etc/ssl/certs
+      volumes:
+      - name: etcd-cert-dir
+        hostPath:
+          path: /usr/share/ca-certificates/
+          type: Directory
+---
+##########################################################################
+# Authchecker deployment
+##########################################################################
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: {{ template "fullname" . }}-authchecker
+  labels:
+    app: {{ template "fullname" . }}-authchecker
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}-authchecker
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}-authchecker
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+        heritage: "{{ .Release.Service }}"
+    spec:
+      containers:
+      - name: osdsauthchecker
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+          allowPrivilegeEscalation: true
+        image: {{ .Values.osdsauthchecker.image }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        ports:
+        - containerPort: 80
+---

--- a/charts/opensds/templates/service.yaml
+++ b/charts/opensds/templates/service.yaml
@@ -1,16 +1,157 @@
+# Copyright (c) 2019 The OpenSDS Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+##########################################################################
+# Apiserver service
+##########################################################################
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ template "fullname" . }}-opensds
+  name: {{ template "fullname" . }}-apiserver
   labels:
-    app: {{ template "fullname" . }}-opensds
+    app: {{ template "fullname" . }}-apiserver
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
   selector:
-    app: {{ template "fullname" . }}-opensds
+    app: {{ template "fullname" . }}-apiserver
+  type: {{ .Values.osdsapiserver.service.type }}
   ports:
-  - protocol: TCP
+  - name: http-apiserver
     port: 50040
-    targetPort: 50040
+    {{- if eq .Values.osdsapiserver.service.type "NodePort" }}
+    nodePort: {{ .Values.osdsapiserver.service.nodePort.securePort }}
+    {{- end }}
+---
+##########################################################################
+# Controller service
+##########################################################################
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ template "fullname" . }}-controller
+  labels:
+    app: {{ template "fullname" . }}-controller
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  selector:
+    app: {{ template "fullname" . }}-controller
+  type: {{ .Values.osdslet.service.type }}
+  ports:
+  - name: tcp-controller
+    port: 50049
+    {{- if eq .Values.osdslet.service.type "NodePort" }}
+    nodePort: {{ .Values.osdslet.service.nodePort.securePort }}
+    {{- end }}
+---
+##########################################################################
+# Dock service
+##########################################################################
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ template "fullname" . }}-dock
+  labels:
+    app: {{ template "fullname" . }}-dock
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  selector:
+    app: {{ template "fullname" . }}-dock
+  type: {{ .Values.osdsdock.service.type }}
+  ports:
+  - name: tcp-dock
+    port: 50050
+    {{- if eq .Values.osdsdock.service.type "NodePort" }}
+    nodePort: {{ .Values.osdsdock.service.nodePort.securePort }}
+    {{- end }}
+---
+##########################################################################
+# Dashboard service
+##########################################################################
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ template "fullname" . }}-dashboard
+  labels:
+    app: {{ template "fullname" . }}-dashboard
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  selector:
+    app: {{ template "fullname" . }}-dashboard
+  type: {{ .Values.osdsdashboard.service.type }}
+  ports:
+  - name: http-dashboard
+    port: 8088
+    {{- if eq .Values.osdsdashboard.service.type "NodePort" }}
+    nodePort: {{ .Values.osdsdashboard.service.nodePort.securePort }}
+    {{- end }}
+---
+##########################################################################
+# DB service
+##########################################################################
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ template "fullname" . }}-db
+  labels:
+    app: {{ template "fullname" . }}-db
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  selector:
+    app: {{ template "fullname" . }}-db
+  type: {{ .Values.osdsdb.service.type }}
+  ports:
+  - name: tcp-db1
+    port: 2379
+    {{- if eq .Values.osdsdb.service.type "NodePort" }}
+    nodePort: {{ .Values.osdsdb.service.nodePort.securePort }}
+    {{- end }}
+  - name: tcp-db2
+    port: 2380
+    {{- if eq .Values.osdsdb.service.type "NodePort" }}
+    nodePort: {{ .Values.osdsdb.service.nodePort.securePort }}
+    {{- end }}
+---
+##########################################################################
+# Authchecker service
+##########################################################################
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ template "fullname" . }}-authchecker
+  labels:
+    app: {{ template "fullname" . }}-authchecker
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  selector:
+    app: {{ template "fullname" . }}-authchecker
+  type: {{ .Values.osdsauthchecker.service.type }}
+  ports:
+  - name: http-authchecker
+    port: 80
+    {{- if eq .Values.osdsauthchecker.service.type "NodePort" }}
+    nodePort: {{ .Values.osdsauthchecker.service.nodePort.securePort }}
+    {{- end }}
+---

--- a/charts/opensds/values.yaml
+++ b/charts/opensds/values.yaml
@@ -2,10 +2,131 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 replicaCount: 1
-image:
-  osdsdb: quay.io/coreos/etcd:latest
-  osdsapiserver: opensdsio/opensds-apiserver:latest
-  osdslet: opensdsio/opensds-controller:latest
-  osdsdock: opensdsio/opensds-dock:latest
 # ImagePullPolicy: valid values are "IfNotPresent", "Never", and "Always"
 imagePullPolicy: IfNotPresent
+osdsapiserver:
+  image: opensdsio/opensds-apiserver:latest
+  # Attributes of the apiserver's service resource
+  service:
+    # Type of service; valid values are "LoadBalancer", "NodePort" and "ClusterIP"
+    # NodePort is useful if deploying on bare metal or hacking locally on
+    # minikube
+    type: ClusterIP
+    # Further configuration for services of type NodePort
+    nodePort:
+      # Available port in allowable range (e.g. 30000 - 32767 on minikube)
+      # The TLS-enabled endpoint will be exposed here
+      # securePort: 30040
+  # Apiserver resource requests and limits
+  resources:
+    requests:
+      cpu: 100m
+      memory: 20Mi
+    limits:
+      cpu: 100m
+      memory: 30Mi
+osdslet:
+  image: opensdsio/opensds-controller:latest
+  # Attributes of the controller's service resource
+  service:
+    # Type of service; valid values are "LoadBalancer", "NodePort" and "ClusterIP"
+    # NodePort is useful if deploying on bare metal or hacking locally on
+    # minikube
+    type: ClusterIP
+    # Further configuration for services of type NodePort
+    nodePort:
+      # Available port in allowable range (e.g. 30000 - 32767 on minikube)
+      # The TLS-enabled endpoint will be exposed here
+      # securePort: 30049
+  # Apiserver resource requests and limits
+  resources:
+    requests:
+      cpu: 100m
+      memory: 20Mi
+    limits:
+      cpu: 100m
+      memory: 30Mi
+osdsdock:
+  image: opensdsio/opensds-dock:latest
+  # Attributes of the dock's service resource
+  service:
+    # Type of service; valid values are "LoadBalancer", "NodePort" and "ClusterIP"
+    # NodePort is useful if deploying on bare metal or hacking locally on
+    # minikube
+    type: ClusterIP
+    # Further configuration for services of type NodePort
+    nodePort:
+      # Available port in allowable range (e.g. 30000 - 32767 on minikube)
+      # The TLS-enabled endpoint will be exposed here
+      # securePort: 30050
+  # Apiserver resource requests and limits
+  resources:
+    requests:
+      cpu: 100m
+      memory: 30Mi
+    limits:
+      cpu: 100m
+      memory: 40Mi
+osdsdashboard:
+  image: opensdsio/dashboard:latest
+  # Attributes of the dashboard's service resource
+  service:
+    # Type of service; valid values are "LoadBalancer", "NodePort" and "ClusterIP"
+    # NodePort is useful if deploying on bare metal or hacking locally on
+    # minikube
+    type: NodePort
+    # Further configuration for services of type NodePort
+    nodePort:
+      # Available port in allowable range (e.g. 30000 - 32767 on minikube)
+      # The TLS-enabled endpoint will be exposed here
+      securePort: 31975
+  # Dashboard resource requests and limits
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+    limits:
+      cpu: 100m
+      memory: 200Mi
+osdsdb:
+  image: quay.io/coreos/etcd:latest
+  # Attributes of the database's service resource
+  service:
+    # Type of service; valid values are "LoadBalancer", "NodePort" and "ClusterIP"
+    # NodePort is useful if deploying on bare metal or hacking locally on
+    # minikube
+    type: ClusterIP
+    # Further configuration for services of type NodePort
+    nodePort:
+      # Available port in allowable range (e.g. 30000 - 32767 on minikube)
+      # The TLS-enabled endpoint will be exposed here
+      # securePort: 30050
+  # Database resource requests and limits
+  resources:
+    requests:
+      cpu: 100m
+      memory: 30Mi
+    limits:
+      cpu: 100m
+      memory: 40Mi
+osdsauthchecker:
+  image: opensdsio/opensds-authchecker:latest
+  # Attributes of the authchecker's service resource
+  service:
+    # Type of service; valid values are "LoadBalancer", "NodePort" and "ClusterIP"
+    # NodePort is useful if deploying on bare metal or hacking locally on
+    # minikube
+    type: ClusterIP
+    # Further configuration for services of type NodePort
+    nodePort:
+      # Available port in allowable range (e.g. 30000 - 32767 on minikube)
+      # The TLS-enabled endpoint will be exposed here
+      # securePort: 30050
+  # Authchecker resource requests and limits
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+    limits:
+      cpu: 100m
+      memory: 200Mi


### PR DESCRIPTION
Considering opensds has supported all containerized deployment, helm charts should also need to update the latest version.