### PR TITLE
Add NFS driver in installation

### DIFF
--- a/ansible/group_vars/nfs/nfs.yaml
+++ b/ansible/group_vars/nfs/nfs.yaml
@@ -1,0 +1,35 @@
+# Copyright 2019 The OpenSDS Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+tgtBindIp: 127.0.0.1 # change tgtBindIp to your real host ip, run 'ifconfig' to check
+tgtConfDir: /etc/tgt/conf.d
+pool:
+  opensds-nfs:
+    storageType: file
+    availabilityZone: default
+    extras:
+      dataStorage:
+        provisioningPolicy: Thin
+        isSpaceEfficient: false
+        storageAccessCapability:
+          - Read
+          - Write
+          - Execute
+      ioConnectivity:
+        accessProtocol: nfs
+        maxIOPS: 7000000
+        maxBWS: 600
+      advanced:
+        diskType: SSD
+        latency: 5ms

--- a/ansible/group_vars/osdsdock.yml
+++ b/ansible/group_vars/osdsdock.yml
@@ -22,10 +22,10 @@ dummy:
 # GENERAL #
 ###########
 
-# Change it according to your backend, currently support 'lvm', 'ceph', 'cinder'
+# Change it according to your backend, currently support 'lvm', 'ceph', 'cinder', 'nfs'
 # DISABLE OR COMMENT "enabled_backends: lvm" IF YOU WANT TO INSTALL DIFFERENT BACKENDS ON MULTI-NODES AND mention it in "local.hosts" file
 # Comment this part if you want to use different backends on different nodes
-enabled_backends: lvm #For Multi-backend add backends here, for eg. enabled_backends: lvm,ceph,cinder
+enabled_backends: lvm,nfs #For Multi-backend add backends here, for eg. enabled_backends: lvm,ceph,cinder,nfs
 
 # Change it according to your node type (host or target), currently support
 # 'provisioner', 'attacher'
@@ -94,3 +94,16 @@ cinder_name: cinder backend
 cinder_description: This is a cinder backend service
 cinder_driver_name: cinder
 cinder_config_path: "{{ opensds_driver_config_dir }}/cinder.yaml"
+
+
+###########
+#   NFS   #
+###########
+
+
+# These fields are NOT suggested to be modified
+nfs_name: nfs backend
+nfs_description: This is a nfs backend service
+nfs_driver_name: nfs
+nfs_config_path: "{{ opensds_driver_config_dir }}/nfs.yaml"
+opensds_nfs_group: opensds-nfs

--- a/ansible/roles/cleaner/scenarios/backend.yml
+++ b/ansible/roles/cleaner/scenarios/backend.yml
@@ -163,3 +163,70 @@
   become: true
   when: "'cinder' in enabled_backends"
   ignore_errors: yes
+
+
+- name: clean the volume group of nfs
+  shell:
+    _raw_params: |
+
+      # _clean_lvm_volume_group removes all default LVM volumes
+      #
+      # Usage: _clean_lvm_volume_group $vg
+      function _clean_lvm_volume_group {
+          local vg=$1
+
+          # Clean out existing volumes
+          sudo lvremove -f $vg
+      }
+
+      # _remove_lvm_volume_group removes the volume group
+      #
+      # Usage: _remove_lvm_volume_group $vg
+      function _remove_lvm_volume_group {
+          local vg=$1
+
+          # Remove the volume group
+          sudo vgremove -f $vg
+      }
+
+      # _clean_lvm_backing_file() removes the backing file of the
+      # volume group
+      #
+      # Usage: _clean_lvm_backing_file() $backing_file
+      function _clean_lvm_backing_file {
+          local backing_file=$1
+
+          # If the backing physical device is a loop device, it was probably setup by DevStack
+          if [[ -n "$backing_file" ]] && [[ -e "$backing_file" ]]; then
+              local vg_dev
+              vg_dev=$(sudo losetup -j $backing_file | awk -F':' '/'.img'/ { print $1}')
+              if [[ -n "$vg_dev" ]]; then
+                  sudo losetup -d $vg_dev
+              fi
+              rm -f $backing_file
+          fi
+      }
+
+      # clean_lvm_volume_group() cleans up the volume group and removes the
+      # backing file
+      #
+      # Usage: clean_lvm_volume_group $vg
+      function clean_lvm_volume_group {
+          local vg=$1
+
+          _clean_lvm_volume_group $vg
+          _remove_lvm_volume_group $vg
+          # if there is no logical volume left, it's safe to attempt a cleanup
+          # of the backing file
+          if [[ -z "$(sudo lvs --noheadings -o lv_name $vg 2>/dev/null)" ]]; then
+              _clean_lvm_backing_file {{ cinder_data_dir }}/${vg}.img
+          fi
+      }
+
+      clean_lvm_volume_group {{opensds_nfs_group}}
+
+  args:
+    executable: /bin/bash
+  become: true
+  when: "'nfs' in enabled_backends"
+  ignore_errors: yes

--- a/ansible/roles/osdsdock/scenarios/nfs.yml
+++ b/ansible/roles/osdsdock/scenarios/nfs.yml
@@ -1,0 +1,87 @@
+# Copyright 2019 The OpenSDS Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: install external package and ibv* commands package when nfs backend enabled
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - lvm2
+    - tgt
+    - thin-provisioning-tools
+
+- name: configure nfs section in opensds global info if specify nfs backend
+  shell: |
+    cat >> opensds.conf <<OPENSDS_GLOABL_CONFIG_DOC
+
+    [nfs]
+    name = {{ nfs_name }}
+    description = {{ nfs_description }}
+    driver_name = {{ nfs_driver_name }}
+    config_path = {{ nfs_config_path }}
+  args:
+    chdir: "{{ opensds_config_dir }}"
+  become: yes
+
+- name: copy opensds nfs backend file to nfs config path if specify nfs backend
+  copy:
+    src: ../../../group_vars/nfs/nfs.yaml
+    dest: "{{ nfs_config_path }}"
+
+- name: update opensds nfs backend file if specify nfs backend
+  replace:
+    path: "{{ nfs_config_path }}"
+    regexp: "{{ item.regexp }}"
+    replace: "{{ item.replace }}"
+  with_items:
+    - { regexp: '127.0.0.1', replace: '{{host_ip}}'}
+    - { regexp: 'opensds-nfs', replace: '{{opensds_nfs_group}}'}
+
+- name: create directory to volume group file
+  file:
+    path: "{{ hotpot_work_dir }}/volumegroups"
+    state: directory
+    recurse: yes
+
+- name: create volume group for nfs server if specify nfs backend
+  shell:
+    _raw_params: |
+      function _create_lvm_volume_group {
+          local vg=$1
+          local size=$2
+
+          local backing_file={{ hotpot_work_dir }}/volumegroups/${vg}.img
+          if ! sudo vgs $vg; then
+              # Only create if the file doesn't already exists
+              [[ -f $backing_file ]] || truncate -s $size $backing_file
+              local vg_dev
+              vg_dev=`sudo losetup -f --show $backing_file`
+
+              # Only create physical volume if it doesn't already exist
+              if ! sudo pvs $vg_dev; then
+                  sudo pvcreate $vg_dev
+              fi
+
+              # Only create volume group if it doesn't already exist
+              if ! sudo vgs $vg; then
+                  sudo vgcreate $vg $vg_dev
+              fi
+          fi
+      }
+      modprobe dm_thin_pool
+      _create_lvm_volume_group {{ opensds_nfs_group }} 10G
+  args:
+    executable: /bin/bash
+  become: true

--- a/ansible/roles/osdsdock/tasks/main.yml
+++ b/ansible/roles/osdsdock/tasks/main.yml
@@ -28,6 +28,11 @@
   when:
     - use_cinder_standalone == false and "cinder" in enabled_backends
 
+- name: include scenarios/nfs.yml
+  include: scenarios/nfs.yml
+  when:
+    - "'nfs' in enabled_backends"
+
 - name: include scenarios/cinder_standalone.yml
   include: scenarios/cinder_standalone.yml
   when:


### PR DESCRIPTION
This PR will add NFS backend into opensds-installer that initialises nfs dock and pool automatically. Since opensds-installer supports multi-backends, therefore I set `lvm,nfs` as default backend list.