### PR TITLE
Telemetry: Install and enable sysstat

### DIFF
--- a/ansible/roles/telemetry-installer/scenarios/install_telemetry_tools.yml
+++ b/ansible/roles/telemetry-installer/scenarios/install_telemetry_tools.yml
@@ -214,3 +214,4 @@
     - echo 'ENABLED="true"' > /etc/default/sysstat
     - service sysstat restart
   become: yes
+  

--- a/ansible/roles/telemetry-installer/scenarios/install_telemetry_tools.yml
+++ b/ansible/roles/telemetry-installer/scenarios/install_telemetry_tools.yml
@@ -204,3 +204,13 @@
   with_items:
     - systemctl status grafana-server
   become: yes
+# ---------install sysstat and enable collection---------
+- name: install sysstat
+  shell: "{{ item }}"
+  tags:
+    - collection
+  with_items:
+    - apt-get install sysstat -y
+    - echo 'ENABLED="true"' > /etc/default/sysstat
+    - service sysstat restart
+  become: yes


### PR DESCRIPTION
Installed should install and enable sysstat utility on lvm to collect metrics. This should be installed only if telemetry install is enabled.