### PR TITLE
Telemetry: fix for #163 - Install lvm exporter

### DIFF
--- a/ansible/roles/telemetry-installer/scenarios/clean_telemetry_tools.yml
+++ b/ansible/roles/telemetry-installer/scenarios/clean_telemetry_tools.yml
@@ -80,3 +80,15 @@
     - apt purge -y sysstat    
   ignore_errors: yes
   become: yes
+
+# ---------start to clean lvm_exporter---------
+- name: clean lvm_exporter
+  shell: "{{ item }}"
+  tags:
+    - lvm_exporter_clean
+  with_items:
+    - systemctl stop lvm_exporter
+    - rm -rf /etc/systemd/system/lvm_exporter.service
+    - rm -rf /usr/local/bin/lvm_exporter
+  ignore_errors: yes
+  become: yes

--- a/ansible/roles/telemetry-installer/scenarios/install_telemetry_tools.yml
+++ b/ansible/roles/telemetry-installer/scenarios/install_telemetry_tools.yml
@@ -148,7 +148,79 @@
     - systemctl restart prometheus
     - systemctl status prometheus
   become: yes
+# ---------start to install sysstat---------
+- name: install sysstat
+  shell: "{{ item }}"
+  with_items:
+    - apt-get install -y sysstat
+    - sed -i 's/^ENABLED=.*/ENABLED="true"/g' /etc/default/sysstat
+    - systemctl restart sysstat
+  become: yes
 
+- name: check status of sysstat service
+  shell: "{{ item }}"
+  with_items:
+    - systemctl status sysstat
+  become: yes
+
+# ---------start  lvm_exporter---------
+- name: copy lvm_exporter
+  shell: "{{ item }}"
+  tags:
+    - lvm_exporter
+  with_items:
+    - cp /opt/opensds-hotpot-linux-amd64/bin/lvm_exporter /usr/local/bin/
+    - chown root:root /usr/local/bin/lvm_exporter
+  become: yes
+
+- name: edit lvm_exporter.service
+  shell: "{{ item }}"
+  tags:
+    - lvm_exporter
+  with_items:
+    - bash ./script/set_lvm_exporter_service.sh
+  become: yes
+
+- name: start lvm_exporter
+  shell: "{{ item }}"
+  tags:
+    - lvm_exporter
+  with_items:
+    - systemctl daemon-reload
+    - systemctl start lvm_exporter
+  become: yes
+
+- name: check status of lvm_exporter service
+  shell: "{{ item }}"
+  tags:
+    - lvm_exporter
+  with_items:
+    - systemctl status lvm_exporter
+  become: yes
+
+- name: configuring prometheus to scrape lvm_exporter
+  tags:
+    - lvm_exporter
+  shell: "{{ item }}"
+  with_items:
+    - bash ./script/mod_prometheus_config_for_lvm_exporter.sh
+  become: yes
+
+- name: restart prometheus
+  tags:
+    - lvm_exporter
+  shell: "{{ item }}"
+  with_items:
+    - systemctl restart prometheus
+  become: yes
+
+- name: check status of prometheus service
+  tags:
+    - lvm_exporter
+  shell: "{{ item }}"
+  with_items:
+    - systemctl status prometheus
+  become: yes
 # ---------start to install alertmanager---------
 - name: download alertmanager
   shell: "{{ item }}"
@@ -280,73 +352,5 @@
   when: prometheus_push_mechanism == 'PushGateway'
   tags: telemetry_conf
 
-# ---------start to install sysstat---------
-- name: install sysstat
-  shell: "{{ item }}"
-  with_items:
-    - apt-get install -y sysstat
-    - sed -i 's/^ENABLED=.*/ENABLED="true"/g' /etc/default/sysstat
-    - systemctl restart sysstat
-  become: yes
-  
-- name: check status of sysstat service
-  shell: "{{ item }}"
-  with_items:
-    - systemctl status sysstat
-  become: yes
 
-# ---------start  lvm_exporter---------
-- name: copy lvm_exporter
-  shell: "{{ item }}"
-  tags:
-    - lvm_exporter
-  with_items:
-    - cp /opt/opensds-hotpot-linux-amd64/bin/lvm_exporter /usr/local/bin/
-    - chown root:root /usr/local/bin/lvm_exporter
-  become: yes
-
-- name: edit lvm_exporter.service
-  shell: "{{ item }}"
-  tags:
-    - lvm_exporter
-  with_items:
-    - bash ./script/set_lvm_exporter_service.sh
-  become: yes
-
-- name: start lvm_exporter
-  shell: "{{ item }}"
-  tags:
-    - lvm_exporter
-  with_items:
-    - systemctl daemon-reload
-    - systemctl start lvm_exporter
-  become: yes
-
-- name: check status of lvm_exporter service
-  shell: "{{ item }}"
-  tags:
-    - lvm_exporter
-  with_items:
-    - systemctl status lvm_exporter
-  become: yes
-
-- name: configuring prometheus to scrape lvm_exporter
-  tags:
-    - lvm_exporter
-  shell: "{{ item }}"
-  with_items:
-    - bash ./script/mod_prometheus_config_for_lvm_exporter.sh
-  become: yes
-
-- name: restart prometheus
-  shell: "{{ item }}"
-  with_items:
-    - systemctl restart prometheus
-  become: yes
-
-- name: check status of prometheus service
-  shell: "{{ item }}"
-  with_items:
-    - systemctl status prometheus
-  become: yes
   

--- a/ansible/roles/telemetry-installer/scenarios/install_telemetry_tools.yml
+++ b/ansible/roles/telemetry-installer/scenarios/install_telemetry_tools.yml
@@ -295,3 +295,58 @@
     - systemctl status sysstat
   become: yes
 
+# ---------start  lvm_exporter---------
+- name: copy lvm_exporter
+  shell: "{{ item }}"
+  tags:
+    - lvm_exporter
+  with_items:
+    - cp /opt/opensds-hotpot-linux-amd64/bin/lvm_exporter /usr/local/bin/
+    - chown root:root /usr/local/bin/lvm_exporter
+  become: yes
+
+- name: edit lvm_exporter.service
+  shell: "{{ item }}"
+  tags:
+    - lvm_exporter
+  with_items:
+    - bash ./script/set_lvm_exporter_service.sh
+  become: yes
+
+- name: start lvm_exporter
+  shell: "{{ item }}"
+  tags:
+    - lvm_exporter
+  with_items:
+    - systemctl daemon-reload
+    - systemctl start lvm_exporter
+  become: yes
+
+- name: check status of lvm_exporter service
+  shell: "{{ item }}"
+  tags:
+    - lvm_exporter
+  with_items:
+    - systemctl status lvm_exporter
+  become: yes
+
+- name: configuring prometheus to scrape lvm_exporter
+  tags:
+    - lvm_exporter
+  shell: "{{ item }}"
+  with_items:
+    - bash ./script/mod_prometheus_config_for_lvm_exporter.sh
+  become: yes
+
+- name: restart prometheus
+  shell: "{{ item }}"
+  with_items:
+    - systemctl restart prometheus
+  become: yes
+
+- name: check status of prometheus service
+  shell: "{{ item }}"
+  with_items:
+    - systemctl status prometheus
+  become: yes
+  

--- a/ansible/roles/telemetry-installer/tasks/main.yml
+++ b/ansible/roles/telemetry-installer/tasks/main.yml
@@ -14,8 +14,12 @@
 
 ---
 - name: include scenarios/clean_telemetry_tools.yml
+  tags:
+    - telemetry
   include: scenarios/clean_telemetry_tools.yml
   when: clean_up_before_installation == true
 
 - name: include scenarios/install_telemetry_tools.yml
+  tags:
+    - telemetry
   include: scenarios/install_telemetry_tools.yml

--- a/ansible/script/mod_prometheus_config_for_lvm_exporter.sh
+++ b/ansible/script/mod_prometheus_config_for_lvm_exporter.sh
@@ -20,3 +20,4 @@ cat >> /etc/prometheus/prometheus.yml <<EOF
     static_configs:
       - targets: ['localhost:8080']
 EOF
+

--- a/ansible/script/mod_prometheus_config_for_lvm_exporter.sh
+++ b/ansible/script/mod_prometheus_config_for_lvm_exporter.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2019 The OpenSDS Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cat >> /etc/prometheus/prometheus.yml <<EOF
+  - job_name: 'lvm_exporter'
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['localhost:8080']
+EOF

--- a/ansible/script/set_lvm_exporter_service.sh
+++ b/ansible/script/set_lvm_exporter_service.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2019 The OpenSDS Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cat > /etc/systemd/system/lvm_exporter.service <<EOF
+[Unit]
+Description=lvm Exporter
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=root
+Group=root
+Type=simple
+ExecStart=/usr/local/bin/lvm_exporter
+
+[Install]
+WantedBy=multi-user.target
+
+EOF


### PR DESCRIPTION
installer should run lvm_exporter by default as a system service if telemetry install is enabled .
duplicate of https://github.com/opensds/opensds-installer/pull/167 , which  is closed due to lot of conflicts while merging.