### PR TITLE
Separate known failure task of orchestration install

### DIFF
--- a/ansible/roles/cleaner/tasks/main.yml
+++ b/ansible/roles/cleaner/tasks/main.yml
@@ -119,3 +119,4 @@
 - name: include scenarios/orchestration.yml for cleaning up orchestration service
   include_tasks: scenarios/orchestration.yml
   when: install_orchestration == true
+  tags: orchestration_tag

--- a/ansible/roles/orchestration-installer/scenarios/stackstorm.yml
+++ b/ansible/roles/orchestration-installer/scenarios/stackstorm.yml
@@ -46,7 +46,13 @@
   with_items:
    - docker cp contrib/st2/opensds {{ container_id.stdout }}:/opt/stackstorm/packs/
    - docker exec -i {{ container_id.stdout }} st2ctl reload --register-all
-   - docker exec -i {{ container_id.stdout }} st2 run packs.setup_virtualenv packs=opensds
+  args:
+    chdir: "{{ orchestration_work_dir }}"
+    warn: false
+  become: yes
+
+- name: Install virtualenv for opensds packs [This task is known failure]
+  shell: docker exec -i {{ container_id.stdout }} st2 run packs.setup_virtualenv packs=opensds
   args:
     chdir: "{{ orchestration_work_dir }}"
     warn: false


### PR DESCRIPTION
This PR will separate the knwon failure. And report failure when virtualenv for OpenSDS pack of StackStorm installed and ignore this failure.