### PR TITLE
Fixes opensds/opensds-dashboard # 106. Added the nginx conf change for orchestration api server.

### DIFF
--- a/ansible/script/set_nginx_config.sh
+++ b/ansible/script/set_nginx_config.sh
@@ -17,7 +17,8 @@
 TOP_DIR=$(cd $(dirname "$0") && pwd)
 source "$TOP_DIR/util.sh"
 source "$TOP_DIR/sdsrc"
-
+#FIXME The /orchestration/  changes are to fix  Issue #106 in opensds/opensds-dashboard. 
+#This is a temporary fix for the API not being reachable. The Orchestration API endpoint will be changed and this fix will be removed.
 cat > /etc/nginx/sites-available/default <<EOF
     server {
         listen 8088 default_server;
@@ -30,6 +31,9 @@ cat > /etc/nginx/sites-available/default <<EOF
         }
         location /v1beta/ {
             proxy_pass http://$HOST_IP:50040/$OPENSDS_VERSION/;
+        }
+        location /orchestration/ {
+            proxy_pass http://$HOST_IP:5000/orchestration/;
         }
         location /v1/ {
             proxy_pass http://$HOST_IP:8089/v1/;


### PR DESCRIPTION
Fixes [opensds/opensds-dashboard # 106](https://github.com/opensds/opensds-dashboard/issues/106)
The nginx configuration for the orchestration api server needs to be modified.  
Currently all the opensds apis are being served on /v1beta on the 50040 port. Orchestration apis are being served on /v1beta as well but on the 5000 port.   
The routes have to be matched and the API calls have to be rerouted to the appropriate endpoints by the nginx conf. This will be fixed in subsequent PRs