### PR TITLE
Remove repeated common role execution

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -74,3 +74,6 @@
     src: ../../../../conf/
     dest: "{{ opensds_config_dir }}"
   when: deploy_project != "gelato"
+
+- set_fact: common_role_done=True
+  when: common_role_done is not defined

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -51,6 +51,7 @@
   tasks:
     - import_role:
         name: common
+      when: common_role_done is not defined
     - import_role:
         name: osdsdb
     - import_role:
@@ -71,6 +72,7 @@
   tasks:
     - import_role:
         name: common
+      when: common_role_done is not defined
     - import_role:
         name: osdsdock
       when:
@@ -89,6 +91,7 @@
   tasks:
     - import_role:
         name: common
+      when: common_role_done is not defined
     - import_role:
         name: gelato-installer
       when:
@@ -107,6 +110,7 @@
   tasks:
     - import_role:
         name: common
+      when: common_role_done is not defined
     - import_role:
         name: sushi-installer
       when:


### PR DESCRIPTION
This PR will avoid repeated 'common' role execution which is already executed in a host. 

The 'allow_duplicates: false' is not working with import_role/include_role in latest ansible. (https://github.com/ansible/ansible/issues/32888).

This PR uses set_fact module that survive between plays but will not be saved across executions.