### PR TITLE
fix(ansible): add pip install docker-py to osdsdb container installation scenario

### DIFF
--- a/ansible/roles/osdsdb/scenarios/container.yml
+++ b/ansible/roles/osdsdb/scenarios/container.yml
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 ---
+- name: install docker-py package with pip when enabling containerized deployment
+  pip:
+    name: docker-py
 - name: run etcd containerized service
   docker_container:
     name: myetcd


### PR DESCRIPTION
This PR fixes issue #262.

Add docker-py pip installation task to ansible/roles/osdsdb/scenarios/container.yml.

