### PR TITLE
Ansible Ceph integration improvements (#270)

### DIFF
--- a/ansible/group_vars/ceph/all.yml
+++ b/ansible/group_vars/ceph/all.yml
@@ -28,7 +28,7 @@ ceph_repository: community
 ceph_stable_release: luminous
 public_network: "{{ ansible_default_ipv4.address }}/24"
 cluster_network: "{{ public_network }}"
-monitor_interface: eth1
+monitor_interface: "{{ ansible_default_ipv4.interface }}"
 devices:
   #- '/dev/sda'
   #- '/dev/sdb'

--- a/ansible/group_vars/ceph/ceph.yaml
+++ b/ansible/group_vars/ceph/ceph.yaml
@@ -14,7 +14,7 @@
 
 configFile: /etc/ceph/ceph.conf
 pool:
-  rbd: # change pool name same to ceph pool, but don't change it if you choose lvm backend
+  osdsrbd: # change pool name same to ceph pool, but don't change it if you choose lvm backend
     storageType: block
     availabilityZone: default
     extras:

--- a/ansible/group_vars/osdsdock.yml
+++ b/ansible/group_vars/osdsdock.yml
@@ -65,6 +65,9 @@ ceph_description: This is a ceph backend service
 ceph_driver_name: ceph
 ceph_config_path: "{{ opensds_driver_config_dir }}/ceph.yaml"
 
+# constants used in wait logic for ceph stabilization
+ceph_check_interval: 30
+ceph_check_count: 12
 
 ###########
 # CINDER  #

--- a/ansible/group_vars/osdsdock.yml
+++ b/ansible/group_vars/osdsdock.yml
@@ -65,6 +65,11 @@ ceph_description: This is a ceph backend service
 ceph_driver_name: ceph
 ceph_config_path: "{{ opensds_driver_config_dir }}/ceph.yaml"
 
+# ceph-ansible playbook branch to be checked out from:
+# https://github.com/ceph/ceph-ansible
+# stable-3.1 requires ansible 2.4 and supports luminous/mimic.
+ceph_ansible_branch: stable-3.1
+
 # constants used in wait logic for ceph stabilization
 ceph_check_interval: 30
 ceph_check_count: 12

--- a/ansible/group_vars/osdsdock.yml
+++ b/ansible/group_vars/osdsdock.yml
@@ -55,7 +55,7 @@ opensds_volume_group_nvme_size: 10G
 ###########
 
 ceph_pools: # Specify pool name randomly
-  - rbd
+  - osdsrbd
   #- ssd
   #- sas
 

--- a/ansible/roles/osdsdock/scenarios/ceph.yml
+++ b/ansible/roles/osdsdock/scenarios/ceph.yml
@@ -168,17 +168,8 @@
     - cephres["results"][0]["stdout"] != "HEALTH_OK"
     - res["rc"] == 1 or service_ceph_mon_status.rc == 1 or service_ceph_osd_status.rc == 1
 
-- name: check if ceph osd is running
-  shell: ps aux | grep ceph-osd | grep -v grep
-  ignore_errors: true
-  changed_when: false
-  register: service_ceph_osd_status
-
-- name: check if ceph mon is running
-  shell: ps aux | grep ceph-mon | grep -v grep
-  ignore_errors: true
-  changed_when: false
-  register: service_ceph_mon_status
+- name: wait until ceph stabilizes
+  include_tasks: roles/osdsdock/scenarios/ceph_stabilize.yml
 
 - name: configure profile and disable some features in ceph for kernel compatible.
   shell: "{{ item }}"
@@ -188,13 +179,9 @@
     - ceph osd crush tunables hammer
     - sleep 5 
     - grep -q "^rbd default features" /etc/ceph/ceph.conf || sed -i '/\[global\]/arbd default features = 1' /etc/ceph/ceph.conf
-  when:
-    - cephres["results"][0]["stdout"] != "HEALTH_OK"
-    - service_ceph_mon_status.rc == 0 and service_ceph_osd_status.rc == 0
 
 - name: create specified pools and initialize them with default pool size.
   shell: ceph osd pool create {{ item }} 100 && ceph osd pool set {{ item }} size 1
   ignore_errors: yes
   changed_when: false
   with_items: "{{ ceph_pools }}"
-  when: service_ceph_mon_status.rc == 0 and service_ceph_osd_status.rc == 0

--- a/ansible/roles/osdsdock/scenarios/ceph.yml
+++ b/ansible/roles/osdsdock/scenarios/ceph.yml
@@ -13,79 +13,161 @@
 # limitations under the License.
 
 ---
-- name: check ceph exists
-  shell: "{{ item }}"
-  with_items: 
-    - bash ./script/check_ceph_exist.sh
-  ignore_errors: true
-  register: cephres
+- name: ceph pre-flight check
+  include_tasks: roles/osdsdock/scenarios/ceph_preflight_check.yml
 
-- name: check if ceph.conf folder exist when ceph backend enable
-  shell: ls /etc/ceph
+- name: check ceph exists
+  shell: which ceph
+  args:
+    executable: /bin/bash
+  ignore_errors: true
+  register: ceph_existence
+#
+# check installed ceph major version and set it to 'installed_ceph_version'.
+#
+- name: check the installed ceph version
+  shell: ceph --version  | egrep ^ceph | awk '{print $3;}' | cut -d "." -f 1,1
+  args:
+    executable: /bin/bash
   ignore_errors: true
   register: result
+  when: ceph_existence["rc"] == 0
 
-- name: create ceph.conf folder if not exist when ceph backend enable
-  file:
-    path: "{{ item }}"
-    state: directory
-    mode: 0755
-  with_items:
-    - "{{ ceph_backend_conf }}"
-  when: cephres["results"][0]["stdout"] == "HEALTH_OK" and result["rc"] != 0
-
-- name:  configure ceph section when ceph backend exist
+- name: set_fact installed_ceph_version
+  set_fact:
+    installed_ceph_version: "{{ result['stdout']  }}"
+  when:
+    - ceph_existence["rc"] == 0
+#
+# check 'ceph health' and set the result into 'ceph_health'.
+#
+- name: check if the installed ceph is healthy or not
   shell: |
-   cat > ceph_exist.conf
-   cat >> ceph_exist.conf <<EOF    
-    [global]
-    rbd default features = {{ default_feature }}
-    
-    fsid= {{ fsid }}
-    mon initial members= {{ mon_members }}
-    mon host= {{ mon_host }}
-    public network = {{ public_network }}
-    cluster network = {{ cluster_network }}
-    [osd]
-    osd mkfs type = {{ mkfs_type }}
-    osd mkfs options xfs = {{ mkfs_options }}
-    osd mount options xfs = {{ mount_options }}
-    osd journal size = {{ journal_size }}
-       
+    ceph health
   args:
-    chdir: "{{ ceph_backend_conf }}"
-  ignore_errors: yes
-  when: cephres["results"][0]["stdout"] == "HEALTH_OK" and cephres["results"][0]["rc"] == 0
-
-- name: copy ceph config to /etc/ceph
-  copy:
-    backup: yes
-    src: "{{ ceph_backend_conf }}/ceph_exist.conf"
-    dest: "{{ ceph_backend_conf }}/ceph.conf"
-    force: yes
-  when: cephres["results"][0]["stdout"] == "HEALTH_OK" and result["rc"] == 0
-
-- name: check ceph version
-  script: ./script/check_ceph_version.sh 
-  become: yes
+    executable: /bin/bash
+  register: result
   ignore_errors: true
-  register: res
+  when: ceph_existence["rc"] == 0
 
-- name: install ceph-common external package when ceph backend enabled
-  apt:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - ceph-common
-  when: cephres["results"][0]["stdout"] != "HEALTH_OK" and res["rc"] == 1
+- name: set_fact ceph_health
+  set_fact:
+    # workaround
+    ceph_health: "{{ result['stdout'] }}{{ result['stderr'] }}"
+  when: ceph_existence["rc"] == 0
+#
+# check if /etc/ceph/ceph.conf exists or not
+#
+- name: stat /etc/ceph/ceph.conf
+  stat:
+    path: /etc/ceph/ceph.conf
+  register: ceph_conf_stat
 
+- name: paranoia check for "/etc/ceph/ceph.conf" and its consistency
+  fail:
+    msg: "/etc/ceph/ceph.conf exists, but ceph cluster status is not HEALTH_OK. Check your environment."
+  when:
+    - ceph_existence["rc"] == 0
+    - ceph_health != "HEALTH_OK"
+    - ceph_conf_stat.stat.exists
+#
+# check ceph cluster member status. (if all the osds are up.)
+#
+- name: check ceph cluster member status
+  shell: |
+    declare -a ceph_stat_array=()
+    ceph_stat_array=(`sudo ceph -s | awk '/health:/{print $2;}/osd:/{print $2, $4, $6;}'`)
+    # Check the ceph mon cluster status (again).
+    if [ ${ceph_stat_array[0]} -ne "HEALTH_OK" ]; then
+      exit 1
+    fi
+    # Check if at least 1 osd is defined.
+    if [ ${ceph_stat_array[1]} -lt 1]; then
+      exit 1
+    fi
+    # Check if all the defined osds are up.
+    if [ ${ceph_stat_array[1]} -ne ${ceph_stat_array[2]} ]; then
+      exit 1
+    fi
+    exit 0
+  args:
+    executable: /bin/bash
+  ignore_errors: true
+  register: result
+  when:
+    - ceph_existence["rc"] == 0
+    - ceph_health == "HEALTH_OK"
+
+- name: set_fact ceph_cluster_health_status
+  set_fact:
+    ceph_cluster_health_status: "{{ result['rc'] }}"
+  when:
+    - ceph_existence["rc"] == 0
+    - ceph_health == "HEALTH_OK"
+#
+# check installed ceph version
+#   rc: 0 : required version
+#   rc: 1 : older version, upgrade installation requried.
+#   rc: 2 : newer version
+#   rc: 127 : Unkown release (maybe a typo)
+- name: check if the existing ceph is the required version or not
+  shell: |
+    REQUIRED_CEPH_RELEASE={{ ceph_stable_release }}
+    INSTALLED_CEPH_VERSION={{ installed_ceph_version }}
+    REQUIRED_CEPH_VERSION=
+    case ${REQUIRED_CEPH_RELEASE} in
+    luminous) REQUIRED_CEPH_VERSION="12" ;;
+    mimic) REQUIRED_CEPH_VERSION="13" ;;
+    nautilus) REQUIRED_CEPH_VERSION="14" ;;
+    *)
+      echo "Unknown ceph release requested. ${REQUIRED_CEPH_RELEASE}"
+      exit 127
+      ;;
+    esac
+
+    if [ "${INSTALLED_CEPH_VERSION}" -ne "${REQUIRED_CEPH_VERSION}" ]; then
+      if [ "${INSTALLED_CEPH_VERSION}" -lt "${REQUIRED_CEPH_VERSION}" ]; then
+        # upgrade required
+        exit 1
+      else
+        # downgrade required
+        exit 2
+      fi
+    else
+       # required (major) version
+       exit 0
+    fi
+  args:
+    executable: /bin/bash
+  ignore_errors: true
+  register: result
+  failed_when: result["rc"] == 127
+  when:
+    - ceph_existence["rc"] == 0
+
+- name: set_fact ceph_version_check
+  set_fact:
+    ceph_version_check: "{{ result['rc'] }}"
+  when:
+    - ceph_existence["rc"] == 0
+
+- name: Fail if downgrade of the existing ceph required.
+  fail:
+    msg: "Ceph version downgrade is not supported. Aborting.. "
+  when:
+    - ceph_existence["rc"] == 0
+    - ceph_version_check == "2"
+#
+# install notario
+#
 - name: install notario package with pip when ceph backend enabled
   pip:
     name: "{{ item }}"
   with_items:
     - notario
-  when: cephres["results"][0]["stdout"] != "HEALTH_OK"
-
+#
+# configure opensds.conf ceph section
+#
 - name: configure ceph section in opensds global info if specify ceph backend
   shell: |
     cat >> opensds.conf <<OPENSDS_GLOABL_CONFIG_DOC
@@ -104,87 +186,75 @@
     src: ../../../group_vars/ceph/ceph.yaml
     dest: "{{ ceph_config_path }}"
 
-- name: check if ceph osd is running
-  shell: ps aux | grep ceph-osd | grep -v grep
-  ignore_errors: true
-  changed_when: false
-  register: service_ceph_osd_status
-  when: res["rc"] == 0
+#
+# criteria of ceph installation
+#
+# 1. ceph not installed
+# 1-a. 'which ceph' returns 1 #  (most typical case)
+#  -> do install
+#
+# 2. ceph installed, but not configured
+# 2-a HEALTH_OK, and cluster member status is NOT healthy
+#  -> abort
+#  (The pair case is 3-a.)
+# 2-b. not HEALTH_OK
+#  -> do version check,
+#     2-b-1 if ceph ver. is required, do install (and configure).
+#     2-b-2 if ceph ver. is older than required, re-install.
+#     2-b-3 if ceph ver. is new than required, re-install.
 
-- name: check if ceph mon is running
-  shell: ps aux | grep ceph-mon | grep -v grep
-  ignore_errors: true
-  changed_when: false
-  register: service_ceph_mon_status
-  when: res["rc"] == 0
+# 3. ceph installed, and configured properly
+# 3-a. HEALTH_OK, and cluster member status is healthy
+#  -> do version check,
+#     3-a-1 if version OK, just configure opensds ceph backend
+#     3-a-2 if version NG, abort
 
-- name: check for ceph-ansible source code existed
-  stat:
-    path: /opt/ceph-ansible
-  ignore_errors: yes
-  register: cephansibleexisted
-  when: cephres["results"][0]["stdout"] != "HEALTH_OK"
+# case: 3-a-2
+- name: incorrect - older/newer - version ceph is running properly
+  fail:
+    msg: "older version ceph is configure and running properly. Aborting..."
+  when: ((ceph_existence["rc"] == 0) and (ceph_health == "HEALTH_OK") and (ceph_version_check != "0"))
 
-- name: download ceph-ansible source code
-  git:
-    repo: https://github.com/ceph/ceph-ansible.git
-    dest: /opt/ceph-ansible
-    version: "{{ ceph_ansible_branch }}"
-  when:
-    - cephres["results"][0]["stdout"] != "HEALTH_OK"
-    - cephansibleexisted.stat.exists is undefined or cephansibleexisted.stat.exists == false
-    - res["rc"] == 1 or service_ceph_mon_status.rc == 1 or service_ceph_osd_status.rc == 1
+# case: 2-a
+- name: ceph cluster member health check, especially osds are up or not
+  fail:
+    msg: "ceph is HEALTH_OK, but cluster status is no good. Aborting..."
+  when: ((ceph_existence["rc"] == 0) and (ceph_health == "HEALTH_OK") and (ceph_cluster_health_status is defined and ceph_cluster_health_status != "0"))
 
-- name: copy ceph inventory host into ceph-ansible directory
-  copy:
-    src: ../../../group_vars/ceph/ceph.hosts
-    dest: /opt/ceph-ansible/ceph.hosts
-  when: cephres["results"][0]["stdout"] != "HEALTH_OK" and res["rc"] == 1
+# case: 2-b-2, 2-b-3
+#
+# Uninstall older/newer version ceph components before calling ceph-ansible.
+#
+- name: uninstall ceph on upgrade/downgrade installation
+  include_tasks: roles/osdsdock/scenarios/ceph_uninstall.yml
+  when: ((ceph_existence["rc"] == 0) and (ceph_health != "HEALTH_OK") and (ceph_version_check == "1" or ceph_version_check == "2"))
 
-- name: copy ceph all.yml file into ceph-ansible group_vars directory
-  copy:
-    src: ../../../group_vars/ceph/all.yml
-    dest: /opt/ceph-ansible/group_vars/all.yml
-  when: cephres["results"][0]["stdout"] != "HEALTH_OK" and res["rc"] == 1
+# case: 1-a, 2-b-1
+#
+# Call ceph-ansible playbook.
+#
+- name: install ceph
+  include_tasks: roles/osdsdock/scenarios/ceph_install.yml
+  when: ((ceph_existence["rc"] == 0) and (ceph_health != "HEALTH_OK") and (ceph_version_check == "0" or ceph_version_check == "1")) or (ceph_existence["rc"] != 0)
 
-
-- name: copy site.yml in ceph-ansible
-  copy:
-    src: /opt/ceph-ansible/site.yml.sample
-    dest: /opt/ceph-ansible/site.yml
-    remote_src: yes
-  when: cephres["results"][0]["stdout"] != "HEALTH_OK" and res["rc"] == 1
-
-
-- name: ping all hosts and run ceph-ansible playbook
-  shell: "{{ item }}"
-  become: true
-  with_items:
-    - ansible all -m ping -i ceph.hosts
-    - ansible-playbook site.yml -i ceph.hosts | tee /var/log/ceph_ansible.log
-  args:
-    chdir: /opt/ceph-ansible
-  when:
-    - cephres["results"][0]["stdout"] != "HEALTH_OK"
-    - res["rc"] == 1 or service_ceph_mon_status.rc == 1 or service_ceph_osd_status.rc == 1
-
+#
+# Wait until ceph -s returns HEALTH_OK and all the OSDs get up.
+#
 - name: wait until ceph stabilizes
   include_tasks: roles/osdsdock/scenarios/ceph_stabilize.yml
 
-- name: configure profile and disable some features in ceph for kernel compatible.
-  shell: "{{ item }}"
-  become: true
-  ignore_errors: yes
-  with_items:
-    - ceph osd crush tunables hammer
-    - sleep 5 
-    - grep -q "^rbd default features" /etc/ceph/ceph.conf || sed -i '/\[global\]/arbd default features = 1' /etc/ceph/ceph.conf
-
+#
+# Create specified ceph pools.
+# In case integration with an existing ceph cluster, pool parameters might
+# need to be modified. e.g. pg_num So, 'ignore_erros:' is false (default).
 - name: create specified pools and initialize them with default pool size.
   shell: ceph osd pool create {{ item }} 100 && ceph osd pool set {{ item }} size 1
-  ignore_errors: yes
+#  ignore_errors: yes
   changed_when: false
   with_items: "{{ ceph_pools }}"
-
+#
+# In case of a fresh installation, ceph is a bit eventual until pools become
+# visible. So, wait.
+#
 - name: wait until defined ceph pooll are visible
   include_tasks: roles/osdsdock/scenarios/ceph_pool_check.yml

--- a/ansible/roles/osdsdock/scenarios/ceph.yml
+++ b/ansible/roles/osdsdock/scenarios/ceph.yml
@@ -129,7 +129,7 @@
   git:
     repo: https://github.com/ceph/ceph-ansible.git
     dest: /opt/ceph-ansible
-    version: stable-3.0
+    version: "{{ ceph_ansible_branch }}"
   when:
     - cephres["results"][0]["stdout"] != "HEALTH_OK"
     - cephansibleexisted.stat.exists is undefined or cephansibleexisted.stat.exists == false

--- a/ansible/roles/osdsdock/scenarios/ceph.yml
+++ b/ansible/roles/osdsdock/scenarios/ceph.yml
@@ -185,3 +185,6 @@
   ignore_errors: yes
   changed_when: false
   with_items: "{{ ceph_pools }}"
+
+- name: wait until defined ceph pooll are visible
+  include_tasks: roles/osdsdock/scenarios/ceph_pool_check.yml

--- a/ansible/roles/osdsdock/scenarios/ceph_install.yml
+++ b/ansible/roles/osdsdock/scenarios/ceph_install.yml
@@ -1,0 +1,52 @@
+# Copyright 2019 The OpenSDS Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: check for ceph-ansible source code existed
+  stat:
+    path: /opt/ceph-ansible
+  ignore_errors: yes
+  register: cephansibleexisted
+
+- name: download ceph-ansible source code
+  git:
+    repo: https://github.com/ceph/ceph-ansible.git
+    dest: /opt/ceph-ansible
+    version: "{{ ceph_ansible_branch }}"
+  when:
+    - cephansibleexisted.stat.exists is undefined or cephansibleexisted.stat.exists == false
+
+- name: copy ceph inventory host into ceph-ansible directory
+  copy:
+    src: ../../../group_vars/ceph/ceph.hosts
+    dest: /opt/ceph-ansible/ceph.hosts
+
+- name: copy ceph all.yml file into ceph-ansible group_vars directory
+  copy:
+    src: ../../../group_vars/ceph/all.yml
+    dest: /opt/ceph-ansible/group_vars/all.yml
+
+- name: copy site.yml in ceph-ansible
+  copy:
+    src: /opt/ceph-ansible/site.yml.sample
+    dest: /opt/ceph-ansible/site.yml
+    remote_src: yes
+
+- name: ping all hosts and run ceph-ansible playbook
+  shell: "{{ item }}"
+  with_items:
+    - ansible all -m ping -i ceph.hosts
+    - ansible-playbook site.yml -i ceph.hosts | tee /var/log/ceph_ansible.log
+  args:
+    chdir: /opt/ceph-ansible

--- a/ansible/roles/osdsdock/scenarios/ceph_pool_check.yml
+++ b/ansible/roles/osdsdock/scenarios/ceph_pool_check.yml
@@ -1,0 +1,60 @@
+# Copyright 2019 The OpenSDS Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+# ceph_check_interval/ceph_check_count are defined in group_vars/osdsdock.yml
+
+- name: check defined ceph pool status
+  shell: |
+      INTERVAL={{ ceph_check_interval|quote }}
+      MAX_CHECK={{ ceph_check_count|quote }}
+      # flatten is from ansible 2.5
+      for pool in {{ ceph_pools | join(" ") }}
+      do
+          CURRENT_RESULT=1
+          i=0
+          while true
+          do
+              P_INFO=`sudo rados df --format=json-pretty | jq ".pools[] | select(.name == \"${pool}\") | .name"`
+              if [ "${P_INFO}" != "" ]; then
+                  CURRENT_RESULT=0
+                  break
+              fi
+              i=`expr ${i} \+ 1`
+              if [ "${i}" -ge "${MAX_CHECK}" ]; then
+                  break
+              fi
+              sleep ${INTERVAL}
+          done
+          if [ "${CURRENT_RESULT}" -ne "0" ]; then
+              echo "ERROR: ceph pool: ${pool} is not available."
+              exit 1
+          fi
+      done
+      echo "ceph_pools: " {{ ceph_pools | join(" ") | quote }} " available."
+      exit 0
+  args:
+    executable: /bin/bash
+  register: result
+
+- name: ceph sanity check, success case
+  debug:
+    msg: "All the defined pools can be accessible. {{ result['stdout'] }}"
+  when: result['rc'] == 0
+
+- name: ceph sanity check, failure case
+  fail:
+    msg: "Pool creation result check failed. Aborting..."
+  when: result['rc'] != 0
+

--- a/ansible/roles/osdsdock/scenarios/ceph_preflight_check.yml
+++ b/ansible/roles/osdsdock/scenarios/ceph_preflight_check.yml
@@ -1,0 +1,42 @@
+# Copyright 2019 The OpenSDS Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+# FIXME(thatsdone): Currently, this task list supports only all-in-one
+# configuration. Essentially, these checks should be done
+# at ceph-ansible playbook side.
+
+- name: load group_vars/ceph/all.yml for pre-flight checking
+  include_vars:
+    file: group_vars/ceph/all.yml
+  vars:
+    # ugly hack.
+    public_network: 'dummy'
+
+- name: check if 'devices:' is empty or not
+  fail:
+    msg: "devices: is empty. Specify at least one device for osd."
+  when: devices is not defined or devices == None
+
+- name: check if device in 'devices:' exists or not
+  fail:
+    msg: "device: {{ item }} does not exist."
+  when: item.split("/")[2] not in ansible_devices.keys()
+  with_items: "{{ devices }}"
+
+- name: check if 'monitor_interface:' exists or not
+  fail:
+    msg: "monitor_interface: {{ monitor_interface  }} does not exist."
+  when: monitor_interface not in ansible_interfaces
+

--- a/ansible/roles/osdsdock/scenarios/ceph_stabilize.yml
+++ b/ansible/roles/osdsdock/scenarios/ceph_stabilize.yml
@@ -1,0 +1,54 @@
+# Copyright 2019 The OpenSDS Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+# ceph_check_interval/ceph_check_count are defined in group_vars/osdsdock.yml
+- name: ceph cluster sanity check
+  shell: |
+    INTERVAL={{ ceph_check_interval|quote }}
+    MAX_CHECK={{ ceph_check_count|quote }}
+    declare -a ceph_stat_array=()
+    i=0
+    while true
+    do
+        ceph_stat_array=(`sudo ceph -s | awk '/health:/{print $2;}/osd:/{print $2, $4, $6;}'`)
+        # check health status. 3 conditions below
+        # 1) HEALTH_OK means healty mon cluster.
+        # 2) check joined osd num. At least 1 osd.
+        # 3) check joined osds are all up
+        if [ "${ceph_stat_array[0]}" == "HEALTH_OK" ] && \
+           [ "${ceph_stat_array[1]}" -ge 1 ] && \
+           [ "${ceph_stat_array[1]}" -eq "${ceph_stat_array[2]}" ]; then
+            exit 0
+        fi
+        i=`expr ${i} \+ 1`
+        if [ "${i}" -ge "${MAX_CHECK}" ]; then
+            exit 1
+        fi
+        sleep ${INTERVAL}
+    done
+  args:
+    executable: /bin/bash
+  register: result
+
+- name: ceph cluster sanity check, success case
+  debug:
+    msg: "ceph mon/osd status check passed. Ready to create a pool."
+  when: result['rc'] == 0
+
+- name: ceph cluster sanity check, failure case (skip expected)
+  fail:
+    msg: "ceph mon/osd status check failed. Aborting, check ceph -s result."
+  when: result['rc'] != 0
+

--- a/ansible/roles/osdsdock/scenarios/ceph_uninstall.yml
+++ b/ansible/roles/osdsdock/scenarios/ceph_uninstall.yml
@@ -1,0 +1,40 @@
+# Copyright 2019 The OpenSDS Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+- name: get the repository information of the installed ceph-common
+  shell: |
+    REPOS=`apt-cache  policy ceph-common  | grep http | grep -v ubuntu\\.com`
+    if [ "${REPOS}" == "" ]; then
+      exit 0
+    else
+      exit 1
+    fi
+
+  args:
+    executable: /bin/bash
+  ignore_errors: true
+  register: result
+
+- name: check
+  fail:
+    msg: "FATAL. Please clean up external repository apt line for ceph-common"
+  when: result["rc"] == 1
+
+- name: uninstall current ceph-common
+  apt:
+    name: ceph-common
+    state: absent
+    purge: yes
+    autoremove: yes
+    update_cache: yes

--- a/ansible/roles/osdsdock/tasks/main.yml
+++ b/ansible/roles/osdsdock/tasks/main.yml
@@ -18,11 +18,6 @@
   when:
     - "'lvm' in enabled_backends"
 
-- name: ceph pre-flight check
-  include_tasks: scenarios/ceph_preflight_check.yml
-  when:
-    - "'ceph' in enabled_backends"
-
 - name: include scenarios/ceph.yml
   include: scenarios/ceph.yml
   when:

--- a/ansible/roles/osdsdock/tasks/main.yml
+++ b/ansible/roles/osdsdock/tasks/main.yml
@@ -18,6 +18,11 @@
   when:
     - "'lvm' in enabled_backends"
 
+- name: ceph pre-flight check
+  include_tasks: scenarios/ceph_preflight_check.yml
+  when:
+    - "'ceph' in enabled_backends"
+
 - name: include scenarios/ceph.yml
   include: scenarios/ceph.yml
   when:

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -67,7 +67,7 @@
     - group_vars/hotpot.yml
     - group_vars/osdsdb.yml
     - group_vars/osdsdock.yml
-  gather_facts: false
+  gather_facts: true
   become: True
   tasks:
     - import_role:


### PR DESCRIPTION
This PR implements step1, step2 and a part of step3 of #270.

* Improvements:
    * Can be a workaround for #252, #255, opensds/opensds#989 and opensds/opensds#991.
* Supports:
    1. all-in-one opensds+ceph setup onto a fresh xenial box without ceph packages
    2. all-in-one opensds+ceph setup onto a fresh xenial box with distro bundled ceph packages/files but not configured as a ceph client correctly
    3. all-in-one opensds setup onto a xenial box pre-configured as a client against an existing (typically external) ceph cluster
* Changes:
    * Now default branch of ceph-ansible is 'stable-3.1' that supports 'mimic'.
    * Default ceph pool to be created is 'osdsrbd', not 'rbd'.
