### PR TITLE
chore(salt): pin salt to stable 2019.2.0

### DIFF
--- a/salt/salter.sh
+++ b/salt/salter.sh
@@ -24,6 +24,7 @@
 trap exit SIGINT SIGTERM
 [ `id -u` != 0 ] && echo && echo "Run script with sudo, exiting" && echo && exit 1
 
+SALT_VERSION='stable 2019.2.0'    ##stick with stable previous release
 RC=0
 BASE=/srv
 BASE_ETC=/etc


### PR DESCRIPTION
This is workaround for upstream issue https://github.com/saltstack/salt/issues/54765 

 To be fixed in 2019.2.2 (https://github.com/saltstack/salt/pull/54780)