### PR TITLE
Python package requests needed when installing from VirtualBox

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -40,6 +40,10 @@
     - python-pip
     - open-iscsi
 
+- name: install requests package with pip
+  pip:
+    name: requests
+
 - name: install Ubuntu system packages
   package:
     name: "{{ item }}"


### PR DESCRIPTION
OpenSDS installation fails if python package 'requests' is missing in the Ubuntu host system. This PR add installation requests package to installer.

This PR address issue #282