### PR TITLE
Add port usage check to installer

### DIFF
--- a/ansible/roles/auth-installer/tasks/main.yml
+++ b/ansible/roles/auth-installer/tasks/main.yml
@@ -13,6 +13,15 @@
 # limitations under the License.
 
 ---
+- name: check port usage
+  wait_for:
+    port: "{{ item }}"
+    timeout: 5
+    state: stopped
+    msg: "Port {{ item }} is not free"
+  with_items:
+    - 80
+  become: yes
 
 - name: install keystone with the script
   shell: "{{ item }}"


### PR DESCRIPTION
This PR add check for port 80 usage. If it is free installation proceeds otherwise installation fails with message. The keystone installation requires port 80 to be free.

This PR address issue #277