### PR TITLE
Optimizations to re-use downloaded release directories

### DIFF
--- a/ansible/group_vars/common.yml
+++ b/ansible/group_vars/common.yml
@@ -40,3 +40,9 @@ image_tag: v0.6.1
 # This field indicates which os family the system will be running, currently
 # support 'Debian' and 'RedHat'
 ansible_os_family: Debian
+
+# delete all source packages
+source_purge: true
+
+# delete database
+database_purge: true

--- a/ansible/roles/cleaner/tasks/main.yml
+++ b/ansible/roles/cleaner/tasks/main.yml
@@ -57,6 +57,7 @@
     state: absent
     force: yes
   ignore_errors: yes
+  when: database_purge is undefined or database_purge == true
   tags: hotpot
 
 - name: stop all gelato services
@@ -97,7 +98,18 @@
   when: sushi_plugin_type == "csi"
   tags: sushi
 
-- name: clean all configuration and log files in created work directories
+- name: clean all configuration and log files
+  file:
+    path: "{{ item }}"
+    state: absent
+    force: yes
+  with_items:
+    - "{{ opensds_config_dir }}"
+    - "{{ opensds_log_dir }}"
+    - "{{ opensds_certs_dir }}"
+  ignore_errors: yes
+
+- name: clean all created work directories
   file:
     path: "{{ item }}"
     state: absent
@@ -105,12 +117,10 @@
   with_items:
     - "{{ hotpot_work_dir }}"
     - "{{ sushi_work_dir }}"
-    - "{{ opensds_config_dir }}"
-    - "{{ opensds_log_dir }}"
     - "{{ dashboard_work_dir }}"
     - "{{ gelato_work_dir }}"
-    - "{{ opensds_certs_dir }}"
   ignore_errors: yes
+  when: source_purge is undefined or source_purge != false
   tags: clean
 
 - name: include scenarios/auth-keystone.yml when keystone specified

--- a/ansible/roles/common/scenarios/release.yml
+++ b/ansible/roles/common/scenarios/release.yml
@@ -15,7 +15,7 @@
 ---
 - name: check for hotpot release files existed
   stat:
-    path: "{{ hotpot_tarball_dir }}"
+    path: "{{ hotpot_work_dir }}/bin"
   register: hotpotreleasesexisted
 
 - name: download and extract the hotpot release tarball if not exists
@@ -31,9 +31,13 @@
     path: "{{ hotpot_tarball_dir }}/bin"
     mode: 0755
     recurse: yes
+  when:
+    - hotpotreleasesexisted.stat.exists is undefined or hotpotreleasesexisted.stat.exists == false
 
 - name: copy hotpot tarball into hotpot work directory
   copy:
     src: "{{ hotpot_tarball_dir }}/"
     dest: "{{ hotpot_work_dir }}"
     mode: 0755
+  when:
+    - hotpotreleasesexisted.stat.exists is undefined or hotpotreleasesexisted.stat.exists == false

--- a/ansible/roles/gelato-installer/scenarios/release.yml
+++ b/ansible/roles/gelato-installer/scenarios/release.yml
@@ -15,7 +15,7 @@
 ---
 - name: check for gelato release files existed
   stat:
-    path: "{{ gelato_tarball_dir }}/docker-compose.yml"
+    path: "{{ gelato_work_dir }}/docker-compose.yml"
   register: gelatoreleasesexisted
 
 - name: download and extract the gelato release tarball if not exists
@@ -31,6 +31,8 @@
   copy:
     src: "{{ gelato_tarball_dir }}/docker-compose.yml"
     dest: "{{ gelato_work_dir }}"
+  when:
+    - gelatoreleasesexisted.stat.exists is undefined or gelatoreleasesexisted.stat.exists == false
 
 - name: copy gelato s3 into gelato work directory
   copy:

--- a/ansible/roles/sushi-installer/scenarios/release.yml
+++ b/ansible/roles/sushi-installer/scenarios/release.yml
@@ -15,7 +15,7 @@
 ---
 - name: check for sushi release files existed
   stat:
-    path: "{{ sushi_tarball_dir }}"
+    path: "{{ sushi_work_dir }}/bin"
   register: sushireleasesexisted
 
 - name: download and extract the sushi release tarball if not exists
@@ -31,9 +31,13 @@
     path: "{{ sushi_tarball_dir }}/bin"
     mode: 0755
     recurse: yes
+  when:
+    - sushireleasesexisted.stat.exists is undefined or sushireleasesexisted.stat.exists == false
 
 - name: copy sushi tarball into sushi work directory
   copy:
     src: "{{ sushi_tarball_dir }}/"
     dest: "{{ sushi_work_dir }}"
     mode: 0755
+  when:
+    - sushireleasesexisted.stat.exists is undefined or sushireleasesexisted.stat.exists == false

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -56,6 +56,7 @@
       when: common_role_done is not defined
     - import_role:
         name: osdsdb
+      tags: etcd
     - import_role:
         name: hotpot-installer
       when:


### PR DESCRIPTION
This PR address issue #278 and add following features

Add options (source_purge and database_purge) to control delete source files and db before re-install. Installed source packages from /opt folder may be reused in new VM and avoid re-downloading.

