### PR TITLE
Add host policy configuration

### DIFF
--- a/conf/policy.json
+++ b/conf/policy.json
@@ -61,5 +61,10 @@
   "fileshareacl:delete": "rule:admin_or_owner",
   "fileshareacl:list": "rule:admin_or_owner",
   "fileshareacl:get": "rule:admin_or_owner",
-  "fileshareacl:update": "rule:admin_or_owner"
+  "fileshareacl:update": "rule:admin_or_owner",
+  "host:create": "rule:admin_or_owner",
+  "host:delete": "rule:admin_or_owner",
+  "host:list": "rule:admin_or_owner",
+  "host:get": "rule:admin_or_owner",
+  "host:update": "rule:admin_or_owner"
 }


### PR DESCRIPTION
Considering the update of hotpot policy.json, this pr will sync policy.json to installer so that hotpot is able to serve host api: opensds/opensds#1039