### PR TITLE
Replace backend parameter isSpaceEfficient from config files

### DIFF
--- a/ansible/group_vars/ceph/ceph.yaml
+++ b/ansible/group_vars/ceph/ceph.yaml
@@ -20,7 +20,8 @@ pool:
     extras:
       dataStorage:
         provisioningPolicy: Thin
-        isSpaceEfficient: true
+        compression: true
+        deduplication: true
       ioConnectivity:
         accessProtocol: rbd
         maxIOPS: 6000000

--- a/ansible/group_vars/ceph/ceph.yaml
+++ b/ansible/group_vars/ceph/ceph.yaml
@@ -25,7 +25,10 @@ pool:
       ioConnectivity:
         accessProtocol: rbd
         maxIOPS: 6000000
+        minIOPS: 1000000
         maxBWS: 500
+        minBWS: 100
+        latency: 100
       advanced:
         diskType: SSD
         latency: 5ms

--- a/ansible/group_vars/cinder/cinder.yaml
+++ b/ansible/group_vars/cinder/cinder.yaml
@@ -38,7 +38,10 @@ pool:
       ioConnectivity:
         accessProtocol: iscsi
         maxIOPS: 7000000
+        minIOPS: 1000000
         maxBWS: 600
+        minBWS: 100
+        latency: 100
       advanced:
         diskType: SSD
         latency: 3ms

--- a/ansible/group_vars/cinder/cinder.yaml
+++ b/ansible/group_vars/cinder/cinder.yaml
@@ -33,7 +33,8 @@ pool:
     extras:
       dataStorage:
         provisioningPolicy: Thin
-        isSpaceEfficient: false
+        compression: false
+        deduplication: false
       ioConnectivity:
         accessProtocol: iscsi
         maxIOPS: 7000000

--- a/ansible/group_vars/lvm/lvm.yaml
+++ b/ansible/group_vars/lvm/lvm.yaml
@@ -26,7 +26,10 @@ pool:
       ioConnectivity:
         accessProtocol: iscsi
         maxIOPS: 7000000
+        minIOPS: 1000000
         maxBWS: 600
+        minBWS: 100
+        latency: 100
       advanced:
         diskType: SSD
         latency: 5ms

--- a/ansible/group_vars/lvm/lvm.yaml
+++ b/ansible/group_vars/lvm/lvm.yaml
@@ -21,7 +21,8 @@ pool:
     extras:
       dataStorage:
         provisioningPolicy: Thin
-        isSpaceEfficient: false
+        compression: false
+        deduplication: false
       ioConnectivity:
         accessProtocol: iscsi
         maxIOPS: 7000000

--- a/ansible/group_vars/nfs/nfs.yaml
+++ b/ansible/group_vars/nfs/nfs.yaml
@@ -21,7 +21,8 @@ pool:
     extras:
       dataStorage:
         provisioningPolicy: Thin
-        isSpaceEfficient: false
+        compression: false
+        deduplication: false
         storageAccessCapability:
           - Read
           - Write

--- a/ansible/group_vars/nfs/nfs.yaml
+++ b/ansible/group_vars/nfs/nfs.yaml
@@ -30,7 +30,10 @@ pool:
       ioConnectivity:
         accessProtocol: nfs
         maxIOPS: 7000000
+        minIOPS: 1000000
         maxBWS: 600
+        minBWS: 100
+        latency: 100
       advanced:
         diskType: SSD
         latency: 5ms

--- a/charts/OpenSDS Installation using Helm.md
+++ b/charts/OpenSDS Installation using Helm.md
@@ -200,7 +200,10 @@ pool:
       ioConnectivity:
         accessProtocol: iscsi
         maxIOPS: 7000000
+        minIOPS: 1000000
         maxBWS: 600
+        minBWS: 100
+        latency: 100
       advanced:
         diskType: SSD
         latency: 5ms
@@ -223,7 +226,10 @@ pool:
       ioConnectivity:
         accessProtocol: rbd
         maxIOPS: 6000000
+        minIOPS: 1000000
         maxBWS: 500
+        minBWS: 100
+        latency: 100
       advanced:
         diskType: SSD
         latency: 5ms

--- a/charts/OpenSDS Installation using Helm.md
+++ b/charts/OpenSDS Installation using Helm.md
@@ -195,7 +195,8 @@ pool:
     extras:
       dataStorage:
         provisioningPolicy: Thin
-        isSpaceEfficient: false
+        compression: false
+        deduplication: false
       ioConnectivity:
         accessProtocol: iscsi
         maxIOPS: 7000000
@@ -217,7 +218,8 @@ pool:
     extras:
       dataStorage:
         provisioningPolicy: Thin
-        isSpaceEfficient: true
+        compression: true
+        deduplication: true
       ioConnectivity:
         accessProtocol: rbd
         maxIOPS: 6000000


### PR DESCRIPTION
Config files of backend drivers (/etc/opensds/driver/*.yaml) needs to be updated with replaced 'isSpaceEfficient' parameter.