### PR TITLE
Add NetApp ONTAP Backend Support as the South Bound Driver for OpenSDS Hotpot

### DIFF
--- a/ansible/group_vars/netapp/ontap/ontap.yaml
+++ b/ansible/group_vars/netapp/ontap/ontap.yaml
@@ -1,0 +1,21 @@
+backendOptions:
+  version: 1
+  username: "username"
+  password: "password"
+  storageDriverName: "ontap-san"
+  managementLIF: "127.0.0.1"
+  dataLIF: "127.0.0.1"
+  svm: "vserver"
+  igroupName: "opensds"
+pool:
+  ontap-pool:
+    storageType: block
+    availabilityZone: default
+    multiAttach: true
+    extras:
+      dataStorage:
+        provisioningPolicy: Thin
+        compression: false
+        deduplication: false
+      ioConnectivity:
+        accessProtocol: iscsi

--- a/ansible/group_vars/osdsdock.yml
+++ b/ansible/group_vars/osdsdock.yml
@@ -22,7 +22,7 @@ dummy:
 # GENERAL #
 ###########
 
-# Change it according to your backend, currently support 'lvm', 'ceph', 'cinder', 'nfs'
+# Change it according to your backend, currently support 'lvm', 'ceph', 'cinder', 'nfs', 'ontap'
 # DISABLE OR COMMENT "enabled_backends: lvm" IF YOU WANT TO INSTALL DIFFERENT BACKENDS ON MULTI-NODES AND mention it in "local.hosts" file
 # Comment this part if you want to use different backends on different nodes
 enabled_backends: lvm,nfs #For Multi-backend add backends here, for eg. enabled_backends: lvm,ceph,cinder,nfs
@@ -113,3 +113,14 @@ nfs_description: This is a nfs backend service
 nfs_driver_name: nfs
 nfs_config_path: "{{ opensds_driver_config_dir }}/nfs.yaml"
 opensds_nfs_group: opensds-nfs
+
+####################
+#   NetApp ONTAP   #
+####################
+
+
+# These fields are NOT suggested to be modified
+ontap_name: netapp ontap backend
+ontap_description: This is a netapp ontap backend service
+ontap_driver_name: ontap
+ontap_config_path: "{{ opensds_driver_config_dir }}/ontap.yaml"

--- a/ansible/roles/osdsdock/scenarios/ontap.yml
+++ b/ansible/roles/osdsdock/scenarios/ontap.yml
@@ -1,0 +1,41 @@
+# Copyright 2019 The OpenSDS Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+- name: configure opensds global info osdsdock ontap
+  ini_file:
+    path: "{{ opensds_conf_file }}"
+    section: ontap
+    option: "{{ item.option }}"
+    value: "{{ item.value }}"
+  with_items:
+        - { option: name, value: "{{ ontap_name }}" }
+        - { option: description, value: "{{ ontap_description }}" }
+        - { option: driver_name, value: "{{ ontap_driver_name }}" }
+        - { option: config_path, value: "{{ ontap_config_path }}" }
+  become: yes
+
+- name: copy opensds ontap backend file to ontap config path if specify ontap backend
+  copy:
+    src: ../../../group_vars/netapp/ontap/ontap.yaml
+    dest: "{{ ontap_config_path }}"
+
+- name: update opensds ontap backend file if specify ontap backend
+  replace:
+    path: "{{ ontap_config_path }}"
+    regexp: "{{ item.regexp }}"
+    replace: "{{ item.replace }}"
+  with_items:
+    - { regexp: '127.0.0.1', replace: '{{host_ip}}'}

--- a/ansible/roles/osdsdock/tasks/main.yml
+++ b/ansible/roles/osdsdock/tasks/main.yml
@@ -33,6 +33,11 @@
   when:
     - "'nfs' in enabled_backends"
 
+- name: include scenarios/ontap.yml
+  include: scenarios/ontap.yml
+  when:
+    - "'ontap' in enabled_backends"
+
 - name: include scenarios/cinder_standalone.yml
   include: scenarios/cinder_standalone.yml
   when:


### PR DESCRIPTION
**What this PR does / why we need it:**
This PR is to support for Enabling NetApp ONTAP as a backend for the OpenSDS Hotpot

**Which issue this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged):** fixes #308 

**Special notes for your reviewer:**
This is the installer implementation corresponding to the implementation PR opensds/opensds#1135