### PR TITLE
Update NetApp ONTAP SAN Configurations for NetApp ONTAP Driver

### DIFF
--- a/ansible/group_vars/osdsdock.yml
+++ b/ansible/group_vars/osdsdock.yml
@@ -22,7 +22,7 @@ dummy:
 # GENERAL #
 ###########
 
-# Change it according to your backend, currently support 'lvm', 'ceph', 'cinder', 'nfs', 'ontap'
+# Change it according to your backend, currently support 'lvm', 'ceph', 'cinder', 'nfs', 'netapp_ontap_san'
 # DISABLE OR COMMENT "enabled_backends: lvm" IF YOU WANT TO INSTALL DIFFERENT BACKENDS ON MULTI-NODES AND mention it in "local.hosts" file
 # Comment this part if you want to use different backends on different nodes
 enabled_backends: lvm,nfs #For Multi-backend add backends here, for eg. enabled_backends: lvm,ceph,cinder,nfs
@@ -114,13 +114,13 @@ nfs_driver_name: nfs
 nfs_config_path: "{{ opensds_driver_config_dir }}/nfs.yaml"
 opensds_nfs_group: opensds-nfs
 
-####################
-#   NetApp ONTAP   #
-####################
+######################
+#   NetApp ONTAP SAN #
+######################
 
 
 # These fields are NOT suggested to be modified
 ontap_name: netapp ontap backend
-ontap_description: This is a netapp ontap backend service
-ontap_driver_name: ontap
-ontap_config_path: "{{ opensds_driver_config_dir }}/ontap.yaml"
+ontap_description: This is a netapp ontap san backend service
+ontap_driver_name: netapp_ontap_san
+ontap_config_path: "{{ opensds_driver_config_dir }}/netapp_ontap_san.yaml"

--- a/ansible/roles/osdsdock/scenarios/ontap.yml
+++ b/ansible/roles/osdsdock/scenarios/ontap.yml
@@ -17,7 +17,7 @@
 - name: configure opensds global info osdsdock ontap
   ini_file:
     path: "{{ opensds_conf_file }}"
-    section: ontap
+    section: netapp_ontap_san
     option: "{{ item.option }}"
     value: "{{ item.value }}"
   with_items:

--- a/ansible/roles/osdsdock/tasks/main.yml
+++ b/ansible/roles/osdsdock/tasks/main.yml
@@ -36,7 +36,7 @@
 - name: include scenarios/ontap.yml
   include: scenarios/ontap.yml
   when:
-    - "'ontap' in enabled_backends"
+    - "'netapp_ontap_san' in enabled_backends"
 
 - name: include scenarios/cinder_standalone.yml
   include: scenarios/cinder_standalone.yml


### PR DESCRIPTION
**What this PR does / why we need it:**
This PR is to update Configuration for NetApp ONTAP SAN as a backend for the OpenSDS Hotpot

**Which issue this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged):** fixes #308 

**Special notes for your reviewer:**
This is the installer implementation corresponding to the implementation PR opensds/opensds#1135