### PR TITLE
Update the release tag to 0.8.0

### DIFF
--- a/ansible/group_vars/common.yml
+++ b/ansible/group_vars/common.yml
@@ -34,8 +34,8 @@ deploy_project: all
 install_from: release
 # These fields below will specify the tag based on install_from type
 repo_branch: master
-release_version: v0.6.1
-image_tag: v0.6.1
+release_version: v0.8.0
+image_tag: v0.8.0
 
 # This field indicates which os family the system will be running, currently
 # support 'Debian' and 'RedHat'
@@ -50,4 +50,3 @@ database_purge: true
 
 # OpenSDS configuration file
 opensds_conf_file: /etc/opensds/opensds.conf
-

--- a/charts/OpenSDS Installation using Helm.md
+++ b/charts/OpenSDS Installation using Helm.md
@@ -290,9 +290,9 @@ helm install csiplugin-file/ --name={ csiplugin_service_name }
 ### OpenSDS CLI tool
 #### Download cli tool
 ```
-wget https://github.com/opensds/opensds/releases/download/v0.6.1/opensds-hotpot-v0.6.1-linux-amd64.tar.gz 
-tar zxvf opensds-hotpot-v0.6.1-linux-amd64.tar.gz
-cp opensds-hotpot-v0.6.1-linux-amd64/bin/* /usr/local/bin
+wget https://github.com/opensds/opensds/releases/download/v0.8.0/opensds-hotpot-v0.8.0-linux-amd64.tar.gz 
+tar zxvf opensds-hotpot-v0.8.0-linux-amd64.tar.gz
+cp opensds-hotpot-v0.8.0-linux-amd64/bin/* /usr/local/bin
 chmod 755 /usr/local/bin/osdsctl
 
 export OPENSDS_ENDPOINT=http://{{ apiserver_cluster_ip }}:50040
@@ -334,8 +334,8 @@ Logout of the dashboard as admin and login the dashboard again as a non-admin us
 
 #### For CSI Plugin
 ```
-wget https://github.com/opensds/nbp/releases/download/v0.6.1/opensds-sushi-v0.6.1-linux-amd64.tar.gz
-tar zxvf opensds-sushi-v0.6.1-linux-amd64.tar.gz
+wget https://github.com/opensds/nbp/releases/download/v0.8.0/opensds-sushi-v0.8.0-linux-amd64.tar.gz
+tar zxvf opensds-sushi-v0.8.0-linux-amd64.tar.gz
 cd /opensds-sushi-linux-amd64
 ```
 

--- a/charts/csiplugin-block/values.yaml
+++ b/charts/csiplugin-block/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-image: opensdsio/csiplugin-block:v0.6.1
+image: opensdsio/csiplugin-block:v0.8.0
 # ImagePullPolicy: valid values are "IfNotPresent", "Never", and "Always"
 imagePullPolicy: IfNotPresent
 # ImageRestartPolicy: valid values are "Never", and "Always"

--- a/charts/csiplugin-file/values.yaml
+++ b/charts/csiplugin-file/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-image: opensdsio/csiplugin-file:v0.6.1
+image: opensdsio/csiplugin-file:v0.8.0
 # ImagePullPolicy: valid values are "IfNotPresent", "Never", and "Always"
 imagePullPolicy: IfNotPresent
 # ImageRestartPolicy: valid values are "Never", and "Always"

--- a/charts/opensds/values.yaml
+++ b/charts/opensds/values.yaml
@@ -13,7 +13,7 @@ deployments:
 osdsapiserver:
   name: apiserver
   replicaCount: 1
-  image: opensdsio/opensds-apiserver:v0.6.1
+  image: opensdsio/opensds-apiserver:v0.8.0
   # ImagePullPolicy: valid values are "IfNotPresent", "Never", and "Always"
   imagePullPolicy: IfNotPresent
   # Attributes of the apiserver's service resource
@@ -40,7 +40,7 @@ osdsapiserver:
 osdslet:
   name: controller
   replicaCount: 1
-  image: opensdsio/opensds-controller:v0.6.1
+  image: opensdsio/opensds-controller:v0.8.0
   # ImagePullPolicy: valid values are "IfNotPresent", "Never", and "Always"
   imagePullPolicy: IfNotPresent
   # Attributes of the controller's service resource
@@ -67,7 +67,7 @@ osdslet:
 osdsdock:
   name: dock
   replicaCount: 1
-  image: opensdsio/opensds-dock:v0.6.1
+  image: opensdsio/opensds-dock:v0.8.0
   # ImagePullPolicy: valid values are "IfNotPresent", "Never", and "Always"
   imagePullPolicy: IfNotPresent
   # Attributes of the dock's service resource
@@ -94,7 +94,7 @@ osdsdock:
 osdsdashboard:
   name: dashboard
   replicaCount: 1
-  image: opensdsio/dashboard:v0.6.1
+  image: opensdsio/dashboard:v0.8.0
   # ImagePullPolicy: valid values are "IfNotPresent", "Never", and "Always"
   imagePullPolicy: IfNotPresent
   # Attributes of the dashboard's service resource

--- a/charts/servicebroker/values.yaml
+++ b/charts/servicebroker/values.yaml
@@ -2,7 +2,7 @@
 # Image to use
 name: servicebroker
 image:
-  service-broker: opensdsio/service-broker:v0.6.1
+  service-broker: opensdsio/service-broker:v0.8.0
   etcd-store: quay.io/coreos/etcd:latest
 # ImagePullPolicy; valid values are "IfNotPresent", "Never", and "Always"
 imagePullPolicy: IfNotPresent


### PR DESCRIPTION
This pr will update the rc3 relase tag(0.8.0) in installer config file which will enable user install opensds with the latest release.  It depends on hotpot, gelato, nbp rc3 release. CI will succeed after these projects publish 0.8.0 tag.