### PR TITLE
Add ip and port for etcd running status check

### DIFF
--- a/ansible/roles/osdsdb/scenarios/etcd.yml
+++ b/ansible/roles/osdsdb/scenarios/etcd.yml
@@ -14,7 +14,7 @@
 
 ---
 - name: Check if etcd is running
-  shell: ps aux | grep etcd | grep -v grep
+  shell: ps aux | grep etcd | grep {{ etcd_host }}:{{ etcd_port }} | grep -v grep
   ignore_errors: true
   register: service_etcd_status
 


### PR DESCRIPTION
Add ip and port for etcd running status check to avoid that etcd would not run when another etcd is running on the host.

Type: Bug Fix
Issue: #313 