### PR TITLE
Include contrib folder to distribution target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ dist:
 	    cp -r $(BASE_DIR)/charts $(BUILD_TGT)/ && \
 	    cp -r $(BASE_DIR)/salt $(BUILD_TGT)/ && \
 	    cp -r $(BASE_DIR)/conf $(BUILD_TGT)/ && \
+	    cp -r $(BASE_DIR)/contrib $(BUILD_TGT)/ && \
 	    cp $(BASE_DIR)/LICENSE $(BUILD_TGT)/ && \
 	    zip -r $(DIST_DIR)/$(BUILD_TGT).zip $(BUILD_TGT) && \
 	    tar zcvf $(DIST_DIR)/$(BUILD_TGT).tar.gz $(BUILD_TGT) && \


### PR DESCRIPTION
Add contrib folder to make dist target which is contains grafana configurations