### PR TITLE
[WIP] Helm chart file changes for csi block plugin

### DIFF
--- a/charts/csiplugin-block/templates/_helpers.tpl
+++ b/charts/csiplugin-block/templates/_helpers.tpl
@@ -2,57 +2,57 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "csipluginProvisioner.name" -}}
-{{- default .Chart.Name .Values.csipluginProvisioner.name | trunc 63 | trimSuffix "-" -}}
+{{- define "csiProvisioner.name" -}}
+{{- default .Chart.Name .Values.csiProvisioner.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "csipluginProvisioner.fullname" -}}
+{{- define "csiProvisioner.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s-%s" .Release.Name $name .Values.csipluginProvisioner.name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.csiProvisioner.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 
-{{- define "csipluginAttacher.name" -}}
-{{- default .Chart.Name .Values.csipluginAttacher.name | trunc 63 | trimSuffix "-" -}}
+{{- define "csiAttacher.name" -}}
+{{- default .Chart.Name .Values.csiAttacher.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "csipluginAttacher.fullname" -}}
+{{- define "csiAttacher.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s-%s" .Release.Name $name .Values.csipluginAttacher.name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.csiAttacher.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 
-{{- define "csipluginNodeplugin.name" -}}
-{{- default .Chart.Name .Values.csipluginNodeplugin.name | trunc 63 | trimSuffix "-" -}}
+{{- define "csiNodeplugin.name" -}}
+{{- default .Chart.Name .Values.csiNodeplugin.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "csipluginNodeplugin.fullname" -}}
+{{- define "csiNodeplugin.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s-%s" .Release.Name $name .Values.csipluginNodeplugin.name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.csiNodeplugin.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 
-{{- define "csipluginSnapshotter.name" -}}
-{{- default .Chart.Name .Values.csipluginSnapshotter.name | trunc 63 | trimSuffix "-" -}}
+{{- define "csiSnapshotter.name" -}}
+{{- default .Chart.Name .Values.csiSnapshotter.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "csipluginSnapshotter.fullname" -}}
+{{- define "csiSnapshotter.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s-%s" .Release.Name $name .Values.csipluginSnapshotter.name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.csiSnapshotter.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/charts/csiplugin-block/templates/csi-attacher-opensdsplugin.yaml
+++ b/charts/csiplugin-block/templates/csi-attacher-opensdsplugin.yaml
@@ -4,15 +4,15 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ .Values.csipluginAttacher.name }}
+  name: {{ .Values.csiAttacher.name }}
   labels:
-    app: {{ template "csipluginAttacher.fullname" . }}
+    app: {{ template "csiAttacher.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
   selector:
-    app: {{ template "csipluginAttacher.fullname" . }}
+    app: {{ template "csiAttacher.fullname" . }}
     release: {{ .Release.Name }}
   ports:
     - name: dummy
@@ -22,44 +22,45 @@ spec:
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:
-  name: {{ template "csipluginAttacher.fullname" . }}
+  name: {{ template "csiAttacher.fullname" . }}
   labels:
-    app: {{ template "csipluginAttacher.fullname" . }}
+    app: {{ template "csiAttacher.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  serviceName: {{ .Values.csipluginAttacher.name }}
-  replicas: {{ .Values.csipluginAttacher.replicaCount }}
+  serviceName: {{ .Values.csiAttacher.name }}
+  replicas: {{ .Values.csiAttacher.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "csipluginAttacher.fullname" . }}
+      app: {{ template "csiAttacher.fullname" . }}
       release: {{ .Release.Name }}
   template:
     metadata:
-      name: {{ template "csipluginAttacher.fullname" . }}
+      name: {{ template "csiAttacher.fullname" . }}
       labels:
-        app: {{ template "csipluginAttacher.fullname" . }}
+        app: {{ template "csiAttacher.fullname" . }}
         release: {{ .Release.Name }}
     spec:
       serviceAccount: csi-attacher-block
       containers:
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v1.1.1
+          image: "{{ .Values.csiAttacher.image.repository }}:{{ .Values.csiAttacher.image.tag }}"
+          imagePullPolicy: {{ .Values.csiAttacher.image.pullPolicy }}
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
             - name: iscsi-dir
               mountPath: /etc/iscsi/
         - name: cluster-driver-registrar
-          image: quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1
+          image: "{{ .Values.csiClusterDriverRegistrar.image.repository }}:{{ .Values.csiClusterDriverRegistrar.image.tag }}"
+          imagePullPolicy: {{ .Values.csiClusterDriverRegistrar.image.pullPolicy }}
           args:
             - "--v=5"
             - "--pod-info-mount-version=\"v1\""
@@ -70,8 +71,9 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
-        - name: {{ template "csipluginAttacher.fullname" . }}
-          image: {{ .Values.image }}
+        - name: {{ template "csiAttacher.fullname" . }}
+          image: "{{ .Values.opensdsCsiBlockPlugin.image.repository }}:{{ .Values.opensdsCsiBlockPlugin.image.tag }}"
+          imagePullPolicy: {{ .Values.opensdsCsiBlockPlugin.image.pullPolicy }}
           args :
             - "--csiEndpoint=$(CSI_ENDPOINT)"
             - "--opensdsEndpoint=$(OPENSDS_ENDPOINT)"
@@ -140,7 +142,6 @@ spec:
                 configMapKeyRef:
                   name: csi-configmap-opensdsplugin-block
                   key: osuserdomainid
-          imagePullPolicy: {{ .Values.imagePullPolicy }}
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/charts/csiplugin-block/templates/csi-attacher-rbac.yaml
+++ b/charts/csiplugin-block/templates/csi-attacher-rbac.yaml
@@ -1,12 +1,6 @@
 # This YAML file contains RBAC API objects,
 # which are necessary to run external csi attacher for opensds.
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: csi-attacher-block
-
----
+{{- if .Values.rbac.create }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -47,3 +41,4 @@ roleRef:
   kind: ClusterRole
   name: external-attacher-runner-block
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/csiplugin-block/templates/csi-attacher-serviceaccount.yaml
+++ b/charts/csiplugin-block/templates/csi-attacher-serviceaccount.yaml
@@ -1,0 +1,8 @@
+# This YAML file contains ServiceAccount objects,
+# which are necessary to run external csi attacher for opensds.
+{{- if .Values.serviceAccounts.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-attacher-block
+{{- end }}

--- a/charts/csiplugin-block/templates/csi-nodeplugin-opensdsplugin.yaml
+++ b/charts/csiplugin-block/templates/csi-nodeplugin-opensdsplugin.yaml
@@ -4,22 +4,22 @@
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
-  name: {{ template "csipluginNodeplugin.fullname" . }}
+  name: {{ template "csiNodeplugin.fullname" . }}
   labels:
-    app: {{ template "csipluginNodeplugin.fullname" . }}
+    app: {{ template "csiNodeplugin.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
   selector:
     matchLabels:
-      app: {{ template "csipluginNodeplugin.fullname" . }}
+      app: {{ template "csiNodeplugin.fullname" . }}
       release: {{ .Release.Name }}
   template:
     metadata:
-      name: {{ template "csipluginNodeplugin.fullname" . }}
+      name: {{ template "csiNodeplugin.fullname" . }}
       labels:
-        app: {{ template "csipluginNodeplugin.fullname" . }}
+        app: {{ template "csiNodeplugin.fullname" . }}
         release: {{ .Release.Name }}
     spec:
       tolerations:
@@ -29,7 +29,8 @@ spec:
       hostNetwork: true
       containers:
         - name: node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          image: "{{ .Values.csiNodeplugin.image.repository }}:{{ .Values.csiNodeplugin.image.tag }}"
+          imagePullPolicy: {{ .Values.csiNodeplugin.image.pullPolicy }}
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
@@ -41,19 +42,19 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
-        - name: {{ template "csipluginNodeplugin.fullname" . }}
+        - name: {{ template "csiNodeplugin.fullname" . }}
           securityContext:
             privileged: true
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: {{ .Values.image }}
+          image: "{{ .Values.opensdsCsiBlockPlugin.image.repository }}:{{ .Values.opensdsCsiBlockPlugin.image.tag }}"
+          imagePullPolicy: {{ .Values.opensdsCsiBlockPlugin.image.pullPolicy }}
           args :
             - "--csiEndpoint=$(CSI_ENDPOINT)"
             - "--opensdsEndpoint=$(OPENSDS_ENDPOINT)"
@@ -122,7 +123,6 @@ spec:
                 configMapKeyRef:
                   name: csi-configmap-opensdsplugin-block
                   key: osuserdomainid
-          imagePullPolicy: {{ .Values.imagePullPolicy }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/kubelet/plugins/csi-opensdsplugin-block

--- a/charts/csiplugin-block/templates/csi-nodeplugin-rbac.yaml
+++ b/charts/csiplugin-block/templates/csi-nodeplugin-rbac.yaml
@@ -1,11 +1,5 @@
 # This YAML defines all API objects to create RBAC roles for csi node plugin.
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: csi-nodeplugin-block
-
----
+{{- if .Values.rbac.create }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -42,3 +36,4 @@ roleRef:
   kind: ClusterRole
   name: csi-nodeplugin-block
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/csiplugin-block/templates/csi-nodeplugin-serviceaccount.yaml
+++ b/charts/csiplugin-block/templates/csi-nodeplugin-serviceaccount.yaml
@@ -1,0 +1,7 @@
+# This YAML defines all API objects to create ServiceAccount roles for csi node plugin.
+{{- if .Values.serviceAccounts.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-nodeplugin-block
+{{- end }}

--- a/charts/csiplugin-block/templates/csi-provisioner-opensdsplugin.yaml
+++ b/charts/csiplugin-block/templates/csi-provisioner-opensdsplugin.yaml
@@ -4,15 +4,15 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ .Values.csipluginProvisioner.name }}
+  name: {{ .Values.csiProvisioner.name }}
   labels:
-    app: {{ template "csipluginProvisioner.fullname" . }}
+    app: {{ template "csiProvisioner.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
   selector:
-    app: {{ template "csipluginProvisioner.fullname" . }}
+    app: {{ template "csiProvisioner.fullname" . }}
     release: {{ .Release.Name }}
   ports:
     - name: dummy
@@ -22,30 +22,31 @@ spec:
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:
-  name: {{ template "csipluginProvisioner.fullname" . }}
+  name: {{ template "csiProvisioner.fullname" . }}
   labels:
-    app: {{ template "csipluginProvisioner.fullname" . }}
+    app: {{ template "csiProvisioner.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  serviceName: {{ .Values.csipluginProvisioner.name }}
-  replicas: {{ .Values.csipluginProvisioner.replicaCount }}
+  serviceName: {{ .Values.csiProvisioner.name }}
+  replicas: {{ .Values.csiProvisioner.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "csipluginProvisioner.fullname" . }}
+      app: {{ template "csiProvisioner.fullname" . }}
       release: {{ .Release.Name }}
   template:
     metadata:
-      name: {{ template "csipluginProvisioner.fullname" . }}
+      name: {{ template "csiProvisioner.fullname" . }}
       labels:
-        app: {{ template "csipluginProvisioner.fullname" . }}
+        app: {{ template "csiProvisioner.fullname" . }}
         release: {{ .Release.Name }}
     spec:
       serviceAccount: csi-provisioner-block
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.1.0
+          image: "{{ .Values.csiProvisioner.image.repository }}:{{ .Values.csiProvisioner.image.tag }}"
+          imagePullPolicy: {{ .Values.csiProvisioner.image.pullPolicy }}
           args:
             - "--provisioner=csi-opensdsplugin"
             - "--csi-address=$(ADDRESS)"
@@ -54,12 +55,12 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
-        - name: {{ template "csipluginProvisioner.fullname" . }}
-          image: {{ .Values.image }}
+        - name: {{ template "csiProvisioner.fullname" . }}
+          image: "{{ .Values.opensdsCsiBlockPlugin.image.repository }}:{{ .Values.opensdsCsiBlockPlugin.image.tag }}"
+          imagePullPolicy: {{ .Values.opensdsCsiBlockPlugin.image.pullPolicy }}
           args :
             - "--csiEndpoint=$(CSI_ENDPOINT)"
             - "--opensdsEndpoint=$(OPENSDS_ENDPOINT)"
@@ -123,7 +124,6 @@ spec:
                 configMapKeyRef:
                   name: csi-configmap-opensdsplugin-block
                   key: osuserdomainid
-          imagePullPolicy: {{ .Values.imagePullPolicy }}
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/charts/csiplugin-block/templates/csi-provisioner-rbac.yaml
+++ b/charts/csiplugin-block/templates/csi-provisioner-rbac.yaml
@@ -1,12 +1,6 @@
 # This YAML file contains RBAC API objects,
 # which are necessary to run external csi provisioner for opensds.
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: csi-provisioner-block
-
----
+{{- if .Values.rbac.create }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -55,3 +49,4 @@ roleRef:
   kind: ClusterRole
   name: external-provisioner-runner-block
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/csiplugin-block/templates/csi-provisioner-serviceaccount.yaml
+++ b/charts/csiplugin-block/templates/csi-provisioner-serviceaccount.yaml
@@ -1,0 +1,8 @@
+# This YAML file contains ServiceAccount API objects,
+# which are necessary to run external csi provisioner for opensds.
+{{- if .Values.serviceAccounts.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-provisioner-block
+{{- end }}

--- a/charts/csiplugin-block/templates/csi-snapshotter-opensdsplugin.yaml
+++ b/charts/csiplugin-block/templates/csi-snapshotter-opensdsplugin.yaml
@@ -1,18 +1,18 @@
 # This YAML file contains snapshotter & csi driver API objects,
 # which are necessary to run external csi snapshotter for opensds.
-
+{{- if .Values.csiSnapshotter.enabled }}
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ .Values.csipluginSnapshotter.name }}
+  name: {{ .Values.csiSnapshotter.name }}
   labels:
-    app: {{ template "csipluginSnapshotter.fullname" . }}
+    app: {{ template "csiSnapshotter.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
   selector:
-    app: {{ template "csipluginSnapshotter.fullname" . }}
+    app: {{ template "csiSnapshotter.fullname" . }}
     release: {{ .Release.Name }}
   ports:
     - name: dummy
@@ -22,30 +22,31 @@ spec:
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:
-  name: {{ template "csipluginSnapshotter.fullname" . }}
+  name: {{ template "csiSnapshotter.fullname" . }}
   labels:
-    app: {{ template "csipluginSnapshotter.fullname" . }}
+    app: {{ template "csiSnapshotter.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  serviceName: {{ .Values.csipluginSnapshotter.name }}
-  replicas: {{ .Values.csipluginSnapshotter.replicaCount }}
+  serviceName: {{ .Values.csiSnapshotter.name }}
+  replicas: {{ .Values.csiSnapshotter.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "csipluginSnapshotter.fullname" . }}
+      app: {{ template "csiSnapshotter.fullname" . }}
       release: {{ .Release.Name }}
   template:
     metadata:
-      name: {{ template "csipluginSnapshotter.fullname" . }}
+      name: {{ template "csiSnapshotter.fullname" . }}
       labels:
-        app: {{ template "csipluginSnapshotter.fullname" . }}
+        app: {{ template "csiSnapshotter.fullname" . }}
         release: {{ .Release.Name }}
     spec:
       serviceAccount: csi-snapshotter-block
       containers:
         - name: csi-snapshotter
-          image: quay.io/k8scsi/csi-snapshotter:v1.1.0
+          image: "{{ .Values.csiSnapshotter.image.repository }}:{{ .Values.csiSnapshotter.image.tag }}"
+          imagePullPolicy: {{ .Values.csiSnapshotter.image.pullPolicy }}
           args:
             - "--snapshotter=csi-opensdsplugin"
             - "--csi-address=$(ADDRESS)"
@@ -53,12 +54,12 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
-        - name: {{ template "csipluginSnapshotter.fullname" . }}
-          image: {{ .Values.image }}
+        - name: {{ template "csiSnapshotter.fullname" . }}
+          image: "{{ .Values.opensdsCsiBlockPlugin.image.repository }}:{{ .Values.opensdsCsiBlockPlugin.image.tag }}"
+          imagePullPolicy: {{ .Values.opensdsCsiBlockPlugin.image.pullPolicy }}
           args :
             - "--csiEndpoint=$(CSI_ENDPOINT)"
             - "--opensdsEndpoint=$(OPENSDS_ENDPOINT)"
@@ -127,7 +128,6 @@ spec:
                 configMapKeyRef:
                   name: csi-configmap-opensdsplugin-block
                   key: osuserdomainid
-          imagePullPolicy: {{ .Values.imagePullPolicy }}
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -140,3 +140,4 @@ spec:
           hostPath:
             path: /opt/opensds-security
             type: DirectoryOrCreate
+{{- end }}

--- a/charts/csiplugin-block/templates/csi-snapshotter-rbac.yaml
+++ b/charts/csiplugin-block/templates/csi-snapshotter-rbac.yaml
@@ -1,12 +1,7 @@
 # This YAML file contains RBAC API objects,
 # which are necessary to run external csi snapshotter for opensds.
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: csi-snapshotter-block
-
----
+{{- if .Values.csiSnapshotter.enabled }}
+{{- if .Values.rbac.create }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -56,3 +51,5 @@ roleRef:
   kind: ClusterRole
   name: external-snapshotter-runner-block
   apiGroup: rbac.authorization.k8s.io
+{{- end }}
+{{- end }}

--- a/charts/csiplugin-block/templates/csi-snapshotter-serviceaccount.yaml
+++ b/charts/csiplugin-block/templates/csi-snapshotter-serviceaccount.yaml
@@ -1,0 +1,10 @@
+# This YAML file contains ServiceAccount API objects,
+# which are necessary to run external csi snapshotter for opensds.
+{{- if .Values.csiSnapshotter.enabled }}
+{{- if .Values.serviceAccounts.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-snapshotter-block
+{{- end }}
+{{- end }}

--- a/charts/csiplugin-block/values.yaml
+++ b/charts/csiplugin-block/values.yaml
@@ -1,12 +1,22 @@
 # Default values for opensds csi plugin.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
 
-image: opensdsio/csiplugin-block:v0.6.1
-# ImagePullPolicy: valid values are "IfNotPresent", "Never", and "Always"
-imagePullPolicy: IfNotPresent
-# ImageRestartPolicy: valid values are "Never", and "Always"
-imageRestartPolicy: Never
+serviceAccounts:
+  # Specifies whether serviceaccount resources should be created
+  create: true
+
+#opensdsCsiBlockPlugin spec
+opensdsCsiBlockPlugin:
+  image:
+    repository: opensdsio/csiplugin-block
+    tag: v0.9.0
+    # pullPolicy: valid values are "IfNotPresent", "Never", and "Always"
+    pullPolicy: IfNotPresent
+
 # Please modify data fields in real environment
 data:
   opensdsEndpoint: http://127.0.0.1:50040
@@ -20,19 +30,58 @@ data:
   passwordEncrypter: aes
   enableEncrypted: F
 
-# csipluginProvisioner spec
-csipluginProvisioner:
-  name: csi-provisioner-opensdsplugin-block
+# csiProvisioner spec
+csiProvisioner:
+  name: csi-provisioner
+  image:
+    repository: quay.io/k8scsi/csi-provisioner
+    tag: v1.4.0
+    pullPolicy: IfNotPresent
   replicaCount: 1
-# csipluginAttacher spec
-csipluginAttacher:
-  name: csi-attacher-opensdsplugin-block
+
+# csiAttacher spec
+csiAttacher:
+  name: csi-attacher
+  image:
+    repository: quay.io/k8scsi/csi-attacher
+    tag: v2.1.0
+    pullPolicy: IfNotPresent
   replicaCount: 1
-# csipluginNodeplugin spec
-csipluginNodeplugin:
-  name: csi-nodeplugin-opensdsplugin-block
+
+# csiNodeplugin spec
+csiNodeplugin:
+  name: csi-nodeplugin
+  image:
+    repository: quay.io/k8scsi/csi-node-driver-registrar
+    tag: v1.1.0
+    pullPolicy: IfNotPresent
   replicaCount: 1
-# csipluginSnapshotter spec
-csipluginSnapshotter:
-  name: csi-snapshotter-opensdsplugin-block
+
+# csiClusterDriverRegistrar spec
+csiClusterDriverRegistrar:
+  name: csi-clusterdriverregistrar
+  image:
+    repository: quay.io/k8scsi/csi-cluster-driver-registrar
+    tag: v1.0.1
+    pullPolicy: IfNotPresent
+  replicaCount: 1
+
+# csiSnapshotter spec
+csiSnapshotter:
+  name: csi-snapshotter
+  enabled: true
+  image:
+    repository: quay.io/k8scsi/csi-snapshotter
+    tag: v1.2.2
+    pullPolicy: IfNotPresent
+  replicaCount: 1
+
+# csiResizer spec
+csiResizer:
+  name: csi-resizer
+  enabled: false
+  image:
+    repository: quay.io/k8scsi/csi-resizer
+    tag: v0.4.0
+    pullPolicy: IfNotPresent
   replicaCount: 1


### PR DESCRIPTION
This PR add support for Helm installation for CSI block plugin

This PR has the changes to bring up csi block plugin through helm
Some redundant items in deployment can be removed and it is in progress

Usage:
Refer test report attached below
[test-report.zip](https://github.com/opensds/opensds-installer/files/4159530/test-report.zip)



Test scenarios:
Install csi block plugin in default way through helm
Uninstall csi block plugin 
Install csi block plugin with customized parameters through helm